### PR TITLE
Update PySerDe.py

### DIFF
--- a/datasketches/PySerDe.py
+++ b/datasketches/PySerDe.py
@@ -75,10 +75,10 @@ class PyLongsSerDe(PyObjectSerDe):
     return int(8)
 
   def to_bytes(self, item):
-    return struct.pack('<l', item)
+    return struct.pack('<q', item)
 
   def from_bytes(self, data: bytes, offset: int):
-    val = struct.unpack_from('<l', data, offset)[0]
+    val = struct.unpack_from('<q', data, offset)[0]
     return (val, 8)
 
 


### PR DESCRIPTION
Properly read/write longs as 8-byte (originally wrote bit..oops) values, based on the format table for the struct class: https://docs.python.org/3/library/struct.html#format-characters