### PR TITLE
API cleanup

### DIFF
--- a/include/quantile_conditional.hpp
+++ b/include/quantile_conditional.hpp
@@ -84,7 +84,7 @@ template<typename T, typename SK, typename std::enable_if<std::is_trivial<T>::va
 void add_vector_update(nb::class_<SK>& clazz) {
   clazz.def(
     "update",
-    [](SK& sk, nb::ndarray<T, nb::c_contig> items) {
+    [](SK& sk, nb::ndarray<T> items) {
       if (items.ndim() != 1) {
         throw std::invalid_argument("input data must have only one dimension. Found: "
           + std::to_string(items.ndim()));

--- a/src/count_wrapper.cpp
+++ b/src/count_wrapper.cpp
@@ -31,7 +31,12 @@ void bind_count_min_sketch(nb::module_ &m, const char* name) {
 
   nb::class_<count_min_sketch<W>>(m, name)
     .def(nb::init<uint8_t, uint32_t, uint64_t>(), nb::arg("num_hashes"), nb::arg("num_buckets"), nb::arg("seed")=DEFAULT_SEED,
-         "Creates an instance of a CountMin sketch using nun_hashes (rows), num_buckets (columns), and hash seed `seed`.")
+         "Creates an instance of a CountMin sketch\n\n"
+         ":param num_hashes: Number of rows in the sketch\n:type num_hashes: int\n"
+         ":param num_buckets: Number of columns in the sketch\n:type num_buckets: int\n"
+         ":param seed: Hash seed to use\n:type seed: int, optional"
+         )
+         // using nun_hashes (rows), num_buckets (columns), and hash seed `seed`.)
     .def("__copy__", [](const count_min_sketch<W>& sk){ return count_min_sketch<W>(sk); })
     .def_static("suggest_num_buckets", &count_min_sketch<W>::suggest_num_buckets, nb::arg("relative_error"),
                 "Suggests the number of buckets needed to achieve an accuracy within the provided "

--- a/src/count_wrapper.cpp
+++ b/src/count_wrapper.cpp
@@ -30,8 +30,9 @@ void bind_count_min_sketch(nb::module_ &m, const char* name) {
   using namespace datasketches;
 
   nb::class_<count_min_sketch<W>>(m, name)
-    .def(nb::init<uint8_t, uint32_t, uint64_t>(), nb::arg("num_hashes"), nb::arg("num_buckets"), nb::arg("seed")=DEFAULT_SEED)
-    .def(nb::init<const count_min_sketch<W>&>())
+    .def(nb::init<uint8_t, uint32_t, uint64_t>(), nb::arg("num_hashes"), nb::arg("num_buckets"), nb::arg("seed")=DEFAULT_SEED,
+         "Creates an instance of a CountMin sketch using nun_hashes (rows), num_buckets (columns), and hash seed `seed`.")
+    .def("__copy__", [](const count_min_sketch<W>& sk){ return count_min_sketch<W>(sk); })
     .def_static("suggest_num_buckets", &count_min_sketch<W>::suggest_num_buckets, nb::arg("relative_error"),
                 "Suggests the number of buckets needed to achieve an accuracy within the provided "
                 "relative_error. For example, when relative_error = 0.05, the returned frequency estimates "
@@ -50,16 +51,16 @@ void bind_count_min_sketch(nb::module_ &m, const char* name) {
          "Produces a string summary of the sketch")
     .def("is_empty", &count_min_sketch<W>::is_empty,
          "Returns True if the sketch has seen no items, otherwise False")
-    .def("get_num_hashes", &count_min_sketch<W>::get_num_hashes,
-         "Returns the configured number of hashes for the sketch")
-    .def("get_num_buckets", &count_min_sketch<W>::get_num_buckets,
-         "Returns the configured number of buckets for the sketch")
-    .def("get_seed", &count_min_sketch<W>::get_seed,
-         "Returns the base hash seed for the sketch")
+    .def_prop_ro("num_hashes", &count_min_sketch<W>::get_num_hashes,
+         "The configured number of hashes for the sketch")
+    .def_prop_ro("num_buckets", &count_min_sketch<W>::get_num_buckets,
+         "The configured number of buckets for the sketch")
+    .def_prop_ro("seed", &count_min_sketch<W>::get_seed,
+         "The base hash seed for the sketch")
     .def("get_relative_error", &count_min_sketch<W>::get_relative_error,
          "Returns the maximum permissible error for any frequency estimate query")
-    .def("get_total_weight", &count_min_sketch<W>::get_total_weight,
-         "Returns the total weight currently inserted into the stream")
+    .def_prop_ro("total_weight", &count_min_sketch<W>::get_total_weight,
+         "The total weight currently inserted into the stream")
     .def("update", static_cast<void (count_min_sketch<W>::*)(int64_t, W)>(&count_min_sketch<W>::update), nb::arg("item"), nb::arg("weight")=1.0,
          "Updates the sketch with the given 64-bit integer value")
     .def("update", static_cast<void (count_min_sketch<W>::*)(const std::string&, W)>(&count_min_sketch<W>::update), nb::arg("item"), nb::arg("weight")=1.0,
@@ -73,9 +74,9 @@ void bind_count_min_sketch(nb::module_ &m, const char* name) {
     .def("get_upper_bound", static_cast<W (count_min_sketch<W>::*)(const std::string&) const>(&count_min_sketch<W>::get_upper_bound), nb::arg("item"),
          "Returns an upper bound on the estimate for the provided string")
     .def("get_lower_bound", static_cast<W (count_min_sketch<W>::*)(int64_t) const>(&count_min_sketch<W>::get_lower_bound), nb::arg("item"),
-         "Returns an lower bound on the estimate for the given 64-bit integer value")
+         "Returns a lower bound on the estimate for the given 64-bit integer value")
     .def("get_lower_bound", static_cast<W (count_min_sketch<W>::*)(const std::string&) const>(&count_min_sketch<W>::get_lower_bound), nb::arg("item"),
-         "Returns an lower bound on the estimate for the provided string")
+         "Returns a lower bound on the estimate for the provided string")
     .def("merge", &count_min_sketch<W>::merge, nb::arg("other"),
          "Merges the provided other sketch into this one")
     .def("get_serialized_size_bytes", &count_min_sketch<W>::get_serialized_size_bytes,

--- a/src/cpc_wrapper.cpp
+++ b/src/cpc_wrapper.cpp
@@ -31,7 +31,13 @@ void init_cpc(nb::module_ &m) {
   using namespace datasketches;
 
   nb::class_<cpc_sketch>(m, "cpc_sketch")
-    .def(nb::init<uint8_t, uint64_t>(), nb::arg("lg_k")=cpc_constants::DEFAULT_LG_K, nb::arg("seed")=DEFAULT_SEED)
+    .def(nb::init<uint8_t, uint64_t>(), nb::arg("lg_k")=cpc_constants::DEFAULT_LG_K, nb::arg("seed")=DEFAULT_SEED,
+         "Creates a new CPC sketch\n\n"
+         ":param lg_k: base 2 logarithm of the number of bins in the sketch\n"
+         ":type lg_k: int, optional\n"
+         ":param seed: seed value for the hash function\n"
+         ":type seed: int, optional"
+    )
     .def("__copy__", [](const cpc_sketch& sk){ return cpc_sketch(sk); })
     .def("__str__", &cpc_sketch::to_string,
          "Produces a string summary of the sketch")

--- a/src/cpc_wrapper.cpp
+++ b/src/cpc_wrapper.cpp
@@ -32,7 +32,7 @@ void init_cpc(nb::module_ &m) {
 
   nb::class_<cpc_sketch>(m, "cpc_sketch")
     .def(nb::init<uint8_t, uint64_t>(), nb::arg("lg_k")=cpc_constants::DEFAULT_LG_K, nb::arg("seed")=DEFAULT_SEED)
-    .def(nb::init<const cpc_sketch&>())
+    .def("__copy__", [](const cpc_sketch& sk){ return cpc_sketch(sk); })
     .def("__str__", &cpc_sketch::to_string,
          "Produces a string summary of the sketch")
     .def("to_string", &cpc_sketch::to_string,
@@ -43,8 +43,8 @@ void init_cpc(nb::module_ &m) {
          "Updates the sketch with the given 64-bit floating point")
     .def<void (cpc_sketch::*)(const std::string&)>("update", &cpc_sketch::update, nb::arg("datum"),
          "Updates the sketch with the given string")
-    .def("get_lg_k", &cpc_sketch::get_lg_k,
-         "Returns configured lg_k of this sketch")
+    .def_prop_ro("lg_k", &cpc_sketch::get_lg_k,
+         "Configured lg_k of this sketch")
     .def("is_empty", &cpc_sketch::is_empty,
          "Returns True if the sketch is empty, otherwise False")
     .def("get_estimate", &cpc_sketch::get_estimate,
@@ -70,7 +70,6 @@ void init_cpc(nb::module_ &m) {
 
   nb::class_<cpc_union>(m, "cpc_union")
     .def(nb::init<uint8_t, uint64_t>(), nb::arg("lg_k"), nb::arg("seed")=DEFAULT_SEED)
-    .def(nb::init<const cpc_union&>())
     .def("update", (void (cpc_union::*)(const cpc_sketch&)) &cpc_union::update, nb::arg("sketch"),
          "Updates the union with the provided CPC sketch")
     .def("get_result", &cpc_union::get_result,

--- a/src/density_wrapper.cpp
+++ b/src/density_wrapper.cpp
@@ -42,7 +42,12 @@ void bind_density_sketch(nb::module_ &m, const char* name) {
         { K holder(kernel);
           new (sk) density_sketch<T, K>(k, dim, holder);
         },
-        nb::arg("k"), nb::arg("dim"), nb::arg("kernel"))
+        nb::arg("k"), nb::arg("dim"), nb::arg("kernel"),
+        "Creates a new density sketch\n\n"
+        ":param k: controls the size and error of the sketch\n:type k: int\n"
+        ":param dim: dimension of the input data\n:type dim: int\n"
+        ":param kernel: instance of a kernel\n:type kernel: KernelFunction\n"
+        )
     .def("__copy__", [](const density_sketch<T,K>& sk){ return density_sketch<T,K>(sk); })
     .def("update", static_cast<void (density_sketch<T, K>::*)(const std::vector<T>&)>(&density_sketch<T, K>::update), nb::arg("vector"),
         "Updates the sketch with the given vector")

--- a/src/density_wrapper.cpp
+++ b/src/density_wrapper.cpp
@@ -43,20 +43,21 @@ void bind_density_sketch(nb::module_ &m, const char* name) {
           new (sk) density_sketch<T, K>(k, dim, holder);
         },
         nb::arg("k"), nb::arg("dim"), nb::arg("kernel"))
+    .def("__copy__", [](const density_sketch<T,K>& sk){ return density_sketch<T,K>(sk); })
     .def("update", static_cast<void (density_sketch<T, K>::*)(const std::vector<T>&)>(&density_sketch<T, K>::update), nb::arg("vector"),
         "Updates the sketch with the given vector")
     .def("merge", static_cast<void (density_sketch<T, K>::*)(const density_sketch<T, K>&)>(&density_sketch<T, K>::merge), nb::arg("sketch"),
         "Merges the provided sketch into this one")
     .def("is_empty", &density_sketch<T, K>::is_empty,
         "Returns True if the sketch is empty, otherwise False")
-    .def("get_k", &density_sketch<T, K>::get_k,
-        "Returns the configured parameter k")
-    .def("get_dim", &density_sketch<T, K>::get_dim,
-        "Returns the configured parameter dim")
-    .def("get_n", &density_sketch<T, K>::get_n,
-        "Returns the length of the input stream")
-    .def("get_num_retained", &density_sketch<T, K>::get_num_retained,
-        "Returns the number of retained items (samples) in the sketch")
+    .def_prop_ro("k", &density_sketch<T, K>::get_k,
+        "The configured parameter k")
+    .def_prop_ro("dim", &density_sketch<T, K>::get_dim,
+        "The configured parameter dim")
+    .def_prop_ro("n", &density_sketch<T, K>::get_n,
+        "The length of the input stream")
+    .def_prop_ro("num_retained", &density_sketch<T, K>::get_num_retained,
+        "The number of retained items (samples) in the sketch")
     .def("is_estimation_mode", &density_sketch<T, K>::is_estimation_mode,
         "Returns True if the sketch is in estimation mode, otherwise False")
     .def("get_estimate", &density_sketch<T, K>::get_estimate, nb::arg("point"),
@@ -101,9 +102,12 @@ void init_density(nb::module_ &m) {
   prepare_numpy();
 
   // generic kernel function
-  nb::class_<kernel_function, KernelFunction>(m, "KernelFunction")
+  nb::class_<kernel_function, KernelFunction>(m, "KernelFunction",
+     "KernelFunction provicdes a generic base class from which user-defined kernels must inherit. \
+     The class contains only a __call__ method that must be overridden.")
     .def(nb::init())
-    .def("__call__", &kernel_function::operator(), nb::arg("a"), nb::arg("b"))
+    .def("__call__", &kernel_function::operator(), nb::arg("a"), nb::arg("b"),
+     "A method to evaluate a kernel with given inputs a and b.")
     ;
 
   // the old sketch names can almost be defined, but the kernel_function_holder won't work in init()

--- a/src/ebpps_wrapper.cpp
+++ b/src/ebpps_wrapper.cpp
@@ -34,7 +34,10 @@ void bind_ebpps_sketch(nb::module_ &m, const char* name) {
   using namespace datasketches;
 
   nb::class_<ebpps_sketch<T>>(m, name)
-    .def(nb::init<uint32_t>(), nb::arg("k"))
+    .def(nb::init<uint32_t>(), nb::arg("k"),
+         "Creates a new EBPPS sketch instance\n\n"
+         ":param k: Maximum number of samples in the sketch\n:type k: int\n"
+         )
     .def("__copy__", [](const ebpps_sketch<T>& sk){ return ebpps_sketch<T>(sk); })
     .def("__str__", &ebpps_sketch<T>::to_string,
          "Produces a string summary of the sketch")

--- a/src/ebpps_wrapper.cpp
+++ b/src/ebpps_wrapper.cpp
@@ -35,6 +35,7 @@ void bind_ebpps_sketch(nb::module_ &m, const char* name) {
 
   nb::class_<ebpps_sketch<T>>(m, name)
     .def(nb::init<uint32_t>(), nb::arg("k"))
+    .def("__copy__", [](const ebpps_sketch<T>& sk){ return ebpps_sketch<T>(sk); })
     .def("__str__", &ebpps_sketch<T>::to_string,
          "Produces a string summary of the sketch")
     .def("to_string",
@@ -51,11 +52,11 @@ void bind_ebpps_sketch(nb::module_ &m, const char* name) {
     .def("merge", (void (ebpps_sketch<T>::*)(const ebpps_sketch<T>&)) &ebpps_sketch<T>::merge,
          nb::arg("sketch"), "Merges the sketch with the given sketch")
     .def_prop_ro("k", &ebpps_sketch<T>::get_k,
-         "Returns the sketch's maximum configured sample size")
+         "The sketch's maximum configured sample size")
     .def_prop_ro("n", &ebpps_sketch<T>::get_n,
-         "Returns the total stream length")         
+         "The total stream length")         
     .def_prop_ro("c", &ebpps_sketch<T>::get_c,
-         "Returns the expected number of samples returned upon a call to get_result() or the creation of an iterator. "
+         "The expected number of samples returned upon a call to get_result() or the creation of an iterator. "
          "The number is a floating point value, where the fractional portion represents the probability of including "
          "a \"partial item\" from the sample. The value C should be no larger than the sketch's configured value of k, "
          "although numerical precision limitations mean it may exceed k by double precision floating point error margins in certain cases.")

--- a/src/fi_wrapper.cpp
+++ b/src/fi_wrapper.cpp
@@ -46,6 +46,7 @@ void bind_fi_sketch(nb::module_ &m, const char* name) {
 
   auto fi_class = nb::class_<frequent_items_sketch<T, W, H, E>>(m, name)
     .def(nb::init<uint8_t>(), nb::arg("lg_max_k"))
+    .def("__copy__", [](const frequent_items_sketch<T, W, H, E>& sk){ return frequent_items_sketch<T,W,H,E>(sk); })
     .def("__str__", &frequent_items_sketch<T, W, H, E>::to_string, nb::arg("print_items")=false,
          "Produces a string summary of the sketch")
     .def("to_string", &frequent_items_sketch<T, W, H, E>::to_string, nb::arg("print_items")=false,
@@ -56,10 +57,10 @@ void bind_fi_sketch(nb::module_ &m, const char* name) {
          "Merges the given sketch into this one")
     .def("is_empty", &frequent_items_sketch<T, W, H, E>::is_empty,
          "Returns True if the sketch is empty, otherwise False")
-    .def("get_num_active_items", &frequent_items_sketch<T, W, H, E>::get_num_active_items,
-         "Returns the number of active items in the sketch")
-    .def("get_total_weight", &frequent_items_sketch<T, W, H, E>::get_total_weight,
-         "Returns the sum of the weights (frequencies) in the stream seen so far by the sketch")
+    .def_prop_ro("num_active_items", &frequent_items_sketch<T, W, H, E>::get_num_active_items,
+         "The number of active items in the sketch")
+    .def_prop_ro("total_weight", &frequent_items_sketch<T, W, H, E>::get_total_weight,
+         "The sum of the weights (frequencies) in the stream seen so far by the sketch")
     .def("get_estimate", &frequent_items_sketch<T, W, H, E>::get_estimate, nb::arg("item"),
          "Returns the estimate of the weight (frequency) of the given item.\n"
          "Note: The true frequency of a item would be the sum of the counts as a result of the "
@@ -68,8 +69,8 @@ void bind_fi_sketch(nb::module_ &m, const char* name) {
          "Returns the guaranteed lower bound weight (frequency) of the given item.")
     .def("get_upper_bound", &frequent_items_sketch<T, W, H, E>::get_upper_bound, nb::arg("item"),
          "Returns the guaranteed upper bound weight (frequency) of the given item.")
-    .def("get_sketch_epsilon", (double (frequent_items_sketch<T, W, H, E>::*)(void) const) &frequent_items_sketch<T, W, H, E>::get_epsilon,
-         "Returns the epsilon value used by the sketch to compute error")
+    .def_prop_ro("epsilon", (double (frequent_items_sketch<T, W, H, E>::*)(void) const) &frequent_items_sketch<T, W, H, E>::get_epsilon,
+         "The epsilon value used by the sketch to compute error")
     .def(
         "get_frequent_items",
         [](const frequent_items_sketch<T, W, H, E>& sk, frequent_items_error_type err_type, uint64_t threshold) {

--- a/src/fi_wrapper.cpp
+++ b/src/fi_wrapper.cpp
@@ -45,7 +45,12 @@ void bind_fi_sketch(nb::module_ &m, const char* name) {
   using namespace datasketches;
 
   auto fi_class = nb::class_<frequent_items_sketch<T, W, H, E>>(m, name)
-    .def(nb::init<uint8_t>(), nb::arg("lg_max_k"))
+    .def(nb::init<uint8_t>(), nb::arg("lg_max_k"),
+         "Creates an instance of the sketch\n\n"
+         ":param lg_max_k: base 2 logarithm of the maximum size of the internal hash map of the sketch. Maximum "
+         "capacity is 0.75 of this value, which is the maximum number of distinct items the sketch can contain.\n"
+         ":type lg_max_k: int\n"
+         )
     .def("__copy__", [](const frequent_items_sketch<T, W, H, E>& sk){ return frequent_items_sketch<T,W,H,E>(sk); })
     .def("__str__", &frequent_items_sketch<T, W, H, E>::to_string, nb::arg("print_items")=false,
          "Produces a string summary of the sketch")

--- a/src/hll_wrapper.cpp
+++ b/src/hll_wrapper.cpp
@@ -34,7 +34,16 @@ void init_hll(nb::module_ &m) {
     .export_values();
 
   nb::class_<hll_sketch>(m, "hll_sketch")
-    .def(nb::init<uint8_t, target_hll_type, bool>(), nb::arg("lg_k"), nb::arg("tgt_type")=HLL_8, nb::arg("start_max_size")=false)
+    .def(nb::init<uint8_t, target_hll_type, bool>(), nb::arg("lg_k"), nb::arg("tgt_type")=HLL_8, nb::arg("start_max_size")=false,
+         "Constructs a new HLL sketch\n\n"
+         ":param lg_config_k: A full sketch can hold 2^lg_config_k rows. Must be between 7 and 21, inclusive,\n"
+         ":type lg_config_k: int\n"
+         ":param tgt_type: The HLL mode to use, if/when the sketch reaches estimation mode\n"
+         ":type tgt_type: tgt_hll_type\n"
+         ":param start_full_size: Indicates whether to start in HLL mode, keeping memory use constant (if HLL_6 or "
+         "HLL_8) at the cost of much higher initial memory use. Default (and recommended) is False.\n"
+         ":type start_full_size: bool"
+     )
     .def("__str__", (std::string (hll_sketch::*)(bool,bool,bool,bool) const) &hll_sketch::to_string,
          "Produces a string summary of the sketch")
     .def("to_string", (std::string (hll_sketch::*)(bool,bool,bool,bool) const) &hll_sketch::to_string,
@@ -94,7 +103,11 @@ void init_hll(nb::module_ &m) {
     );
 
   nb::class_<hll_union>(m, "hll_union")
-    .def(nb::init<uint8_t>(), nb::arg("lg_max_k"))
+    .def(nb::init<uint8_t>(), nb::arg("lg_max_k"),
+         "Construct an hll_union object if the given size.\n\n"
+         ":param lg_max_k: The maximum size, in log2, of k. Must be between 7 and 21, inclusive.\n"
+         ":type lg_max_k: int"
+         )
     .def_prop_ro("lg_config_k", &hll_union::get_lg_config_k, "Configured lg_k value for the union")
     .def("get_estimate", &hll_union::get_estimate,
          "Estimate of the distinct count of the input stream")

--- a/src/hll_wrapper.cpp
+++ b/src/hll_wrapper.cpp
@@ -34,17 +34,14 @@ void init_hll(nb::module_ &m) {
     .export_values();
 
   nb::class_<hll_sketch>(m, "hll_sketch")
-    .def(nb::init<uint8_t>(), nb::arg("lg_k"))
-    .def(nb::init<uint8_t, target_hll_type>(), nb::arg("lg_k"), nb::arg("tgt_type"))
-    .def(nb::init<uint8_t, target_hll_type, bool>(), nb::arg("lg_k"), nb::arg("tgt_type"), nb::arg("start_max_size")=false)
+    .def(nb::init<uint8_t, target_hll_type, bool>(), nb::arg("lg_k"), nb::arg("tgt_type")=HLL_8, nb::arg("start_max_size")=false)
     .def("__str__", (std::string (hll_sketch::*)(bool,bool,bool,bool) const) &hll_sketch::to_string,
-         nb::arg("summary")=true, nb::arg("detail")=false, nb::arg("aux_detail")=false, nb::arg("all")=false,
          "Produces a string summary of the sketch")
     .def("to_string", (std::string (hll_sketch::*)(bool,bool,bool,bool) const) &hll_sketch::to_string,
          nb::arg("summary")=true, nb::arg("detail")=false, nb::arg("aux_detail")=false, nb::arg("all")=false,
          "Produces a string summary of the sketch")
     .def_prop_ro("lg_config_k", &hll_sketch::get_lg_config_k, "Configured lg_k value for the sketch")
-    .def_prop_ro("tgt_type", &hll_sketch::get_target_type, "Returns the HLL type (4, 6, or 8) when in estimation mode")
+    .def_prop_ro("tgt_type", &hll_sketch::get_target_type, "The HLL type (4, 6, or 8) when in estimation mode")
     .def("get_estimate", &hll_sketch::get_estimate,
          "Estimate of the distinct count of the input stream")
     .def("get_lower_bound", &hll_sketch::get_lower_bound, nb::arg("num_std_devs"),
@@ -99,7 +96,6 @@ void init_hll(nb::module_ &m) {
   nb::class_<hll_union>(m, "hll_union")
     .def(nb::init<uint8_t>(), nb::arg("lg_max_k"))
     .def_prop_ro("lg_config_k", &hll_union::get_lg_config_k, "Configured lg_k value for the union")
-    .def_prop_ro("tgt_type", &hll_union::get_target_type, "Returns the HLL type (4, 6, or 8) when in estimation mode")
     .def("get_estimate", &hll_union::get_estimate,
          "Estimate of the distinct count of the input stream")
     .def("get_lower_bound", &hll_union::get_lower_bound, nb::arg("num_std_devs"),

--- a/src/kll_wrapper.cpp
+++ b/src/kll_wrapper.cpp
@@ -37,7 +37,11 @@ void bind_kll_sketch(nb::module_ &m, const char* name) {
   using namespace datasketches;
 
   auto kll_class = nb::class_<kll_sketch<T, C>>(m, name)
-    .def(nb::init<uint16_t>(), nb::arg("k")=kll_constants::DEFAULT_K)
+    .def(nb::init<uint16_t>(), nb::arg("k")=kll_constants::DEFAULT_K,
+         "Creates a KLL sketch instance with the given value of k.\n\n"
+         ":param k: Controls the size/accuracy trade-off of the sketch. Default is 200.\n"
+         ":type k: int, optional"
+         )
     .def("__copy__", [](const kll_sketch<T, C>& sk){ return kll_sketch<T, C>(sk); })
     .def("update", static_cast<void (kll_sketch<T, C>::*)(const T&)>(&kll_sketch<T, C>::update), nb::arg("item"),
         "Updates the sketch with the given value")

--- a/src/kll_wrapper.cpp
+++ b/src/kll_wrapper.cpp
@@ -38,23 +38,23 @@ void bind_kll_sketch(nb::module_ &m, const char* name) {
 
   auto kll_class = nb::class_<kll_sketch<T, C>>(m, name)
     .def(nb::init<uint16_t>(), nb::arg("k")=kll_constants::DEFAULT_K)
-    .def(nb::init<const kll_sketch<T, C>&>())
+    .def("__copy__", [](const kll_sketch<T, C>& sk){ return kll_sketch<T, C>(sk); })
     .def("update", static_cast<void (kll_sketch<T, C>::*)(const T&)>(&kll_sketch<T, C>::update), nb::arg("item"),
         "Updates the sketch with the given value")
     .def("merge", (void (kll_sketch<T, C>::*)(const kll_sketch<T, C>&)) &kll_sketch<T, C>::merge, nb::arg("sketch"),
         "Merges the provided sketch into this one")
-    .def("__str__", &kll_sketch<T, C>::to_string, nb::arg("print_levels")=false, nb::arg("print_items")=false,
+    .def("__str__", &kll_sketch<T, C>::to_string,
         "Produces a string summary of the sketch")
     .def("to_string", &kll_sketch<T, C>::to_string, nb::arg("print_levels")=false, nb::arg("print_items")=false,
         "Produces a string summary of the sketch")
     .def("is_empty", &kll_sketch<T, C>::is_empty,
         "Returns True if the sketch is empty, otherwise False")
-    .def("get_k", &kll_sketch<T, C>::get_k,
-        "Returns the configured parameter k")
-    .def("get_n", &kll_sketch<T, C>::get_n,
-        "Returns the length of the input stream")
-    .def("get_num_retained", &kll_sketch<T, C>::get_num_retained,
-        "Returns the number of retained items (samples) in the sketch")
+    .def_prop_ro("k", &kll_sketch<T, C>::get_k,
+        "The configured parameter k")
+    .def_prop_ro("n", &kll_sketch<T, C>::get_n,
+        "The length of the input stream")
+    .def_prop_ro("num_retained", &kll_sketch<T, C>::get_num_retained,
+        "The number of retained items (samples) in the sketch")
     .def("is_estimation_mode", &kll_sketch<T, C>::is_estimation_mode,
         "Returns True if the sketch is in estimation mode, otherwise False")
     .def("get_min_value", &kll_sketch<T, C>::get_min_item,

--- a/src/ks_wrapper.cpp
+++ b/src/ks_wrapper.cpp
@@ -57,7 +57,7 @@ void init_kolmogorov_smirnov(nb::module_ &m) {
     "Performs the Kolmogorov-Smirnov Test between quantiles_floats_sketches.\n"
     "Note: if the given sketches have insufficient data or if the sketch sizes are too small, "
     "this will return false.\n"
-    "Returns True if we can reject the null hypothesis (that the sketches reflect the same underlying "
+    ":Returns True if we can reject the null hypothesis (that the sketches reflect the same underlying "
     "distribution) using the provided p-value, otherwise False.");
   m.def("ks_test", &kolmogorov_smirnov::test<quantiles_sketch<double>>, nb::arg("sk_1"), nb::arg("sk_2"), nb::arg("p"),
     "Performs the Kolmogorov-Smirnov Test between quantiles_doubles_sketches.\n"

--- a/src/py_serde.cpp
+++ b/src/py_serde.cpp
@@ -28,7 +28,8 @@ namespace nb = nanobind;
 
 void init_serde(nb::module_& m) {
   using namespace datasketches;
-  nb::class_<py_object_serde, PyObjectSerDe /* <--- trampoline*/>(m, "PyObjectSerDe")
+  nb::class_<py_object_serde, PyObjectSerDe /* <--- trampoline*/>(m, "PyObjectSerDe",
+    "An abstract base class for serde objects. All custom serdes must extend this class.")
     .def(nb::init<>())
     .def("get_size", &py_object_serde::get_size, nb::arg("item"),
         "Returns the size in bytes of an item")

--- a/src/quantiles_wrapper.cpp
+++ b/src/quantiles_wrapper.cpp
@@ -39,7 +39,7 @@ void bind_quantiles_sketch(nb::module_ &m, const char* name) {
 
   auto quantiles_class = nb::class_<quantiles_sketch<T, C>>(m, name)
     .def(nb::init<uint16_t>(), nb::arg("k")=quantiles_constants::DEFAULT_K)
-    .def(nb::init<const quantiles_sketch<T, C>&>())
+    .def("__copy__", [](const quantiles_sketch<T, C>& sk) { return quantiles_sketch<T,C>(sk); })
     .def(
         "update",
         static_cast<void (quantiles_sketch<T, C>::*)(const T&)>(&quantiles_sketch<T, C>::update),
@@ -48,18 +48,18 @@ void bind_quantiles_sketch(nb::module_ &m, const char* name) {
     )
     .def("merge", (void (quantiles_sketch<T, C>::*)(const quantiles_sketch<T, C>&)) &quantiles_sketch<T, C>::merge, nb::arg("sketch"),
          "Merges the provided sketch into this one")
-    .def("__str__", &quantiles_sketch<T, C>::to_string, nb::arg("print_levels")=false, nb::arg("print_items")=false,
+    .def("__str__", &quantiles_sketch<T, C>::to_string,
          "Produces a string summary of the sketch")
     .def("to_string", &quantiles_sketch<T, C>::to_string, nb::arg("print_levels")=false, nb::arg("print_items")=false,
          "Produces a string summary of the sketch")
     .def("is_empty", &quantiles_sketch<T, C>::is_empty,
          "Returns True if the sketch is empty, otherwise False")
-    .def("get_k", &quantiles_sketch<T, C>::get_k,
-         "Returns the configured parameter k")
-    .def("get_n", &quantiles_sketch<T, C>::get_n,
-         "Returns the length of the input stream")
-    .def("get_num_retained", &quantiles_sketch<T, C>::get_num_retained,
-         "Returns the number of retained items (samples) in the sketch")
+    .def_prop_ro("k", &quantiles_sketch<T, C>::get_k,
+         "The configured parameter k")
+    .def_prop_ro("n", &quantiles_sketch<T, C>::get_n,
+         "The length of the input stream")
+    .def_prop_ro("num_retained", &quantiles_sketch<T, C>::get_num_retained,
+         "The number of retained items (samples) in the sketch")
     .def("is_estimation_mode", &quantiles_sketch<T, C>::is_estimation_mode,
          "Returns True if the sketch is in estimation mode, otherwise False")
     .def("get_min_value", &quantiles_sketch<T, C>::get_min_item,

--- a/src/quantiles_wrapper.cpp
+++ b/src/quantiles_wrapper.cpp
@@ -38,7 +38,11 @@ void bind_quantiles_sketch(nb::module_ &m, const char* name) {
   using namespace datasketches;
 
   auto quantiles_class = nb::class_<quantiles_sketch<T, C>>(m, name)
-    .def(nb::init<uint16_t>(), nb::arg("k")=quantiles_constants::DEFAULT_K)
+    .def(nb::init<uint16_t>(), nb::arg("k")=quantiles_constants::DEFAULT_K,
+         "Creates a classic quantiles sketch instance with the given value of k.\n\n"
+         ":param k: Controls the size/accuracy trade-off of the sketch. Default is 128.\n"
+         ":type k: int, optional"
+    )
     .def("__copy__", [](const quantiles_sketch<T, C>& sk) { return quantiles_sketch<T,C>(sk); })
     .def(
         "update",

--- a/src/req_wrapper.cpp
+++ b/src/req_wrapper.cpp
@@ -38,12 +38,12 @@ void bind_req_sketch(nb::module_ &m, const char* name) {
 
   auto req_class = nb::class_<req_sketch<T, C>>(m, name)
     .def(nb::init<uint16_t, bool>(), nb::arg("k")=12, nb::arg("is_hra")=true)
-    .def(nb::init<const req_sketch<T, C>&>())
+    .def("__copy__", [](const req_sketch<T, C>& sk){ return req_sketch<T, C>(sk); })
     .def("update", (void (req_sketch<T, C>::*)(const T&)) &req_sketch<T, C>::update, nb::arg("item"),
         "Updates the sketch with the given value")
     .def("merge", (void (req_sketch<T, C>::*)(const req_sketch<T, C>&)) &req_sketch<T, C>::merge, nb::arg("sketch"),
         "Merges the provided sketch into this one")
-    .def("__str__", &req_sketch<T, C>::to_string, nb::arg("print_levels")=false, nb::arg("print_items")=false,
+    .def("__str__", &req_sketch<T, C>::to_string,
         "Produces a string summary of the sketch")
     .def("to_string", &req_sketch<T, C>::to_string, nb::arg("print_levels")=false, nb::arg("print_items")=false,
         "Produces a string summary of the sketch")
@@ -51,12 +51,12 @@ void bind_req_sketch(nb::module_ &m, const char* name) {
         "Returns True if the sketch is in High Rank Accuracy mode, otherwise False")
     .def("is_empty", &req_sketch<T, C>::is_empty,
         "Returns True if the sketch is empty, otherwise False")
-    .def("get_k", &req_sketch<T, C>::get_k,
-        "Returns the configured parameter k")
-    .def("get_n", &req_sketch<T, C>::get_n,
-        "Returns the length of the input stream")
-    .def("get_num_retained", &req_sketch<T, C>::get_num_retained,
-        "Returns the number of retained items (samples) in the sketch")
+    .def_prop_ro("k", &req_sketch<T, C>::get_k,
+        "The configured parameter k")
+    .def_prop_ro("n", &req_sketch<T, C>::get_n,
+        "The length of the input stream")
+    .def_prop_ro("num_retained", &req_sketch<T, C>::get_num_retained,
+        "The number of retained items (samples) in the sketch")
     .def("is_estimation_mode", &req_sketch<T, C>::is_estimation_mode,
         "Returns True if the sketch is in estimation mode, otherwise False")
     .def("get_min_value", &req_sketch<T, C>::get_min_item,

--- a/src/req_wrapper.cpp
+++ b/src/req_wrapper.cpp
@@ -37,7 +37,13 @@ void bind_req_sketch(nb::module_ &m, const char* name) {
   using namespace datasketches;
 
   auto req_class = nb::class_<req_sketch<T, C>>(m, name)
-    .def(nb::init<uint16_t, bool>(), nb::arg("k")=12, nb::arg("is_hra")=true)
+    .def(nb::init<uint16_t, bool>(), nb::arg("k")=12, nb::arg("is_hra")=true,
+         "Creates an REQ sketch instance with the given value of k.\n\n"
+         ":param k: Controls the size/accuracy trade-off of the sketch. Default is 12.\n"
+         ":type k: int, optional\n"
+         ":param is_hra: Specifies whether the skech has High Rank Accuracy (True) or Low Rank Accuracy. Default True.\n"
+         ":type is_hra: bool, optional"
+    )
     .def("__copy__", [](const req_sketch<T, C>& sk){ return req_sketch<T, C>(sk); })
     .def("update", (void (req_sketch<T, C>::*)(const T&)) &req_sketch<T, C>::update, nb::arg("item"),
         "Updates the sketch with the given value")

--- a/src/theta_wrapper.cpp
+++ b/src/theta_wrapper.cpp
@@ -50,12 +50,12 @@ void init_theta(nb::module_ &m) {
          "Returns an approximate lower bound on the estimate at standard deviations in {1, 2, 3}")
     .def("is_estimation_mode", static_cast<bool (theta_sketch::*)() const>(&theta_sketch::is_estimation_mode),
          "Returns True if sketch is in estimation mode, otherwise False")
-    .def("get_theta", static_cast<double (theta_sketch::*)() const>(&theta_sketch::get_theta),
-         "Returns theta (effective sampling rate) as a fraction from 0 to 1")
-    .def("get_theta64", static_cast<uint64_t (theta_sketch::*)() const>(&theta_sketch::get_theta64),
-         "Returns theta as 64-bit value")
-    .def("get_num_retained", static_cast<uint32_t (theta_sketch::*)() const>(&theta_sketch::get_num_retained),
-         "Returns the number of items currently in the sketch")
+    .def_prop_ro("theta", static_cast<double (theta_sketch::*)() const>(&theta_sketch::get_theta),
+         "Theta (effective sampling rate) as a fraction from 0 to 1")
+    .def_prop_ro("theta64", static_cast<uint64_t (theta_sketch::*)() const>(&theta_sketch::get_theta64),
+         "Theta as 64-bit value")
+    .def_prop_ro("num_retained", static_cast<uint32_t (theta_sketch::*)() const>(&theta_sketch::get_num_retained),
+         "The number of items currently in the sketch")
     .def("get_seed_hash", static_cast<uint16_t (theta_sketch::*)() const>(&theta_sketch::get_seed_hash),
          "Returns a hash of the seed used in the sketch")
     .def("is_ordered", static_cast<bool (theta_sketch::*)() const>(&theta_sketch::is_ordered),
@@ -77,7 +77,7 @@ void init_theta(nb::module_ &m) {
         },
         nb::arg("lg_k")=theta_constants::DEFAULT_LG_K, nb::arg("p")=1.0, nb::arg("seed")=DEFAULT_SEED
     )
-    .def(nb::init<const update_theta_sketch&>())
+    .def("__copy__", [](const update_theta_sketch& sk){ return update_theta_sketch(sk); })
     .def("update", (void (update_theta_sketch::*)(int64_t)) &update_theta_sketch::update, nb::arg("datum"),
          "Updates the sketch with the given integral value")
     .def("update", (void (update_theta_sketch::*)(double)) &update_theta_sketch::update, nb::arg("datum"),
@@ -91,8 +91,8 @@ void init_theta(nb::module_ &m) {
   ;
 
   nb::class_<compact_theta_sketch, theta_sketch>(m, "compact_theta_sketch")
-    .def(nb::init<const compact_theta_sketch&>())
     .def(nb::init<const theta_sketch&, bool>())
+    .def("__copy__", [](const compact_theta_sketch& sk){ return compact_theta_sketch(sk); })
     .def(
         "serialize",
         [](const compact_theta_sketch& sk) {
@@ -125,7 +125,6 @@ void init_theta(nb::module_ &m) {
 
   nb::class_<theta_intersection>(m, "theta_intersection")
     .def(nb::init<uint64_t>(), nb::arg("seed")=DEFAULT_SEED)
-    .def(nb::init<const theta_intersection&>())
     .def("update", &theta_intersection::update<const theta_sketch&>, nb::arg("sketch"),
          "Intersections the provided sketch with the current intersection state")
     .def("get_result", &theta_intersection::get_result, nb::arg("ordered")=true,

--- a/src/vector_of_kll.cpp
+++ b/src/vector_of_kll.cpp
@@ -525,13 +525,17 @@ void bind_vector_of_kll_sketches(nb::module_ &m, const char* name) {
 
   nb::class_<vector_of_kll_sketches<T>>(m, name)
     .def(nb::init<uint32_t, uint32_t>(), nb::arg("k")=vector_of_kll_constants::DEFAULT_K, 
-                                         nb::arg("d")=vector_of_kll_constants::DEFAULT_D)
-    .def(nb::init<const vector_of_kll_sketches<T>&>())
+                                         nb::arg("d")=vector_of_kll_constants::DEFAULT_D,
+         "Creates a new Vector of KLL Sketches instance with the given values of k and d.\n\n"
+         ":param k: The value of k for every sketch in the vector\n:type k: int\n"
+         ":param d: The number of sketches in the vector\n:type d: int"
+        )
+    .def("__copy__", [](const vector_of_kll_sketches<T>& sk){ return vector_of_kll_sketches<T>(sk); })
     // allow user to retrieve k or d, in case it's instantiated w/ defaults
-    .def("get_k", &vector_of_kll_sketches<T>::get_k,
-         "Returns the value of `k` of the sketch(es)")
-    .def("get_d", &vector_of_kll_sketches<T>::get_d,
-         "Returns the number of sketches")
+    .def_prop_ro("k", &vector_of_kll_sketches<T>::get_k,
+         "The value of `k` of the sketch(es)")
+    .def_prop_ro("d", &vector_of_kll_sketches<T>::get_d,
+         "The number of sketches")
     .def("update", &vector_of_kll_sketches<T>::update, nb::arg("items"), nb::arg("order") = "C",
          "Updates the sketch(es) with value(s).  Must be a 1D array of size equal to the number of sketches.  Can also be 2D array of shape (n_updates, n_sketches).  If a sketch does not have a value to update, use np.nan. "
          " Order 'F' specifies a column-major (Fortran style) matrix; any other value assumes row-major (C style) matrix.")

--- a/src/vo_wrapper.cpp
+++ b/src/vo_wrapper.cpp
@@ -36,6 +36,7 @@ void bind_vo_sketch(nb::module_ &m, const char* name) {
 
   nb::class_<var_opt_sketch<T>>(m, name)
     .def(nb::init<uint32_t>(), nb::arg("k"))
+    .def("__copy__", [](const var_opt_sketch<T>& sk){ return var_opt_sketch<T>(sk); })
     .def("__str__", &var_opt_sketch<T>::to_string,
          "Produces a string summary of the sketch")
     .def("to_string",

--- a/src/vo_wrapper.cpp
+++ b/src/vo_wrapper.cpp
@@ -35,7 +35,10 @@ void bind_vo_sketch(nb::module_ &m, const char* name) {
   using namespace datasketches;
 
   nb::class_<var_opt_sketch<T>>(m, name)
-    .def(nb::init<uint32_t>(), nb::arg("k"))
+    .def(nb::init<uint32_t>(), nb::arg("k"),
+         "Creates a new Var Opt sketch instance\n\n"
+         ":param k: Maximum number of samples in the sketch\n:type k: int\n"
+    )
     .def("__copy__", [](const var_opt_sketch<T>& sk){ return var_opt_sketch<T>(sk); })
     .def("__str__", &var_opt_sketch<T>::to_string,
          "Produces a string summary of the sketch")

--- a/tests/count_min_test.py
+++ b/tests/count_min_test.py
@@ -41,7 +41,7 @@ class CountMinTest(unittest.TestCase):
       cm.update(i, i)
       total_wt += i
     self.assertFalse(cm.is_empty())
-    self.assertEqual(cm.get_total_weight(), total_wt)
+    self.assertEqual(cm.total_weight, total_wt)
 
     # querying the items, each of them should
     # have a non-zero count.  the estimate should
@@ -73,9 +73,9 @@ class CountMinTest(unittest.TestCase):
 
     # and now interrogate the sketch
     self.assertFalse(new_cm.is_empty())
-    self.assertEqual(new_cm.get_num_hashes(), cm.get_num_hashes())
-    self.assertEqual(new_cm.get_num_buckets(), cm.get_num_buckets())
-    self.assertEqual(new_cm.get_total_weight(), cm.get_total_weight())
+    self.assertEqual(new_cm.num_hashes, cm.num_hashes)
+    self.assertEqual(new_cm.num_buckets, cm.num_buckets)
+    self.assertEqual(new_cm.total_weight, cm.total_weight)
     
     # we can also iterate through values in and out of the sketch to ensure
     # the estimates match

--- a/tests/cpc_test.py
+++ b/tests/cpc_test.py
@@ -63,7 +63,7 @@ class CpcTest(unittest.TestCase):
   def test_cpc_get_lg_k(self):
     lgk = 10
     cpc = cpc_sketch(lgk)
-    self.assertEqual(cpc.get_lg_k(), lgk)
+    self.assertEqual(cpc.lg_k, lgk)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/density_test.py
+++ b/tests/density_test.py
@@ -34,21 +34,21 @@ class densityTest(unittest.TestCase):
 
     sketch = density_sketch(k, dim, GaussianKernel())
 
-    self.assertEqual(sketch.get_k(), k)
-    self.assertEqual(sketch.get_dim(), dim)
+    self.assertEqual(sketch.k, k)
+    self.assertEqual(sketch.dim, dim)
     self.assertTrue(sketch.is_empty())
     self.assertFalse(sketch.is_estimation_mode())
-    self.assertEqual(sketch.get_n(), 0)
-    self.assertEqual(sketch.get_num_retained(), 0)
+    self.assertEqual(sketch.n, 0)
+    self.assertEqual(sketch.num_retained, 0)
 
     for i in range(n):
       sketch.update([i, i, i])
 
     self.assertFalse(sketch.is_empty())
     self.assertTrue(sketch.is_estimation_mode())
-    self.assertEqual(sketch.get_n(), n)
-    self.assertGreater(sketch.get_num_retained(), k)
-    self.assertLess(sketch.get_num_retained(), n)
+    self.assertEqual(sketch.n, n)
+    self.assertGreater(sketch.num_retained, k)
+    self.assertLess(sketch.num_retained, n)
     self.assertGreater(sketch.get_estimate([n - 1, n - 1, n - 1]), 0)
 
     for tuple in sketch:
@@ -67,8 +67,8 @@ class densityTest(unittest.TestCase):
     sketch2 = density_sketch(10, 2, GaussianKernel())
     sketch2.update([0, 1])
     sketch1.merge(sketch2)
-    self.assertEqual(sketch1.get_n(), 2)
-    self.assertEqual(sketch1.get_num_retained(), 2)
+    self.assertEqual(sketch1.n, 2)
+    self.assertEqual(sketch1.num_retained, 2)
 
   def test_custom_kernel(self):
     gaussianSketch = density_sketch(10, 2, GaussianKernel())

--- a/tests/fi_test.py
+++ b/tests/fi_test.py
@@ -64,7 +64,7 @@ class FiTest(unittest.TestCase):
     # values but all with equal weight (of 1) such that
     # the total weight is much larger than the first sketch
     fi2 = frequent_strings_sketch(k)
-    wt = fi.get_total_weight()
+    wt = fi.total_weight
     for i in range(0, 4*wt):
       fi2.update(str(i))
 
@@ -72,7 +72,7 @@ class FiTest(unittest.TestCase):
     fi.merge(fi2)
 
     # we can see that the weight is much larger
-    self.assertEqual(5 * wt, fi.get_total_weight())
+    self.assertEqual(5 * wt, fi.total_weight)
 
     # querying with NO_FALSE_POSITIVES means we don't find anything
     # heavy enough to return
@@ -91,8 +91,8 @@ class FiTest(unittest.TestCase):
 
     # and now interrogate the sketch
     self.assertFalse(new_fi.is_empty())
-    self.assertGreater(new_fi.get_num_active_items(), 0)
-    self.assertEqual(5 * wt, new_fi.get_total_weight())
+    self.assertGreater(new_fi.num_active_items, 0)
+    self.assertEqual(5 * wt, new_fi.total_weight)
 
   # This example uses generic objects but is otherwise identical
   def test_fi_items_example(self):
@@ -111,7 +111,7 @@ class FiTest(unittest.TestCase):
     # values but all with equal weight (of 1) such that
     # the total weight is much larger than the first sketch
     fi2 = frequent_items_sketch(k)
-    wt = fi.get_total_weight()
+    wt = fi.total_weight
     for i in range(0, 4*wt):
       fi2.update(i)
 
@@ -119,7 +119,7 @@ class FiTest(unittest.TestCase):
     fi.merge(fi2)
 
     # we can see that the weight is much larger
-    self.assertEqual(5 * wt, fi.get_total_weight())
+    self.assertEqual(5 * wt, fi.total_weight)
 
     # finally, serialize and reconstruct -- now we need a serde to tell
     # (de)serialization how to interpret the objects
@@ -129,8 +129,8 @@ class FiTest(unittest.TestCase):
 
     # and again interrogate the sketch to check that it's what we serialized
     self.assertFalse(new_fi.is_empty())
-    self.assertGreater(new_fi.get_num_active_items(), 0)
-    self.assertEqual(5 * wt, new_fi.get_total_weight())
+    self.assertGreater(new_fi.num_active_items, 0)
+    self.assertEqual(5 * wt, new_fi.total_weight)
 
 
   def test_fi_sketch(self):
@@ -139,9 +139,9 @@ class FiTest(unittest.TestCase):
     wt = 10000
     fi = frequent_strings_sketch(k)
 
-    self.assertAlmostEqual(fi.get_sketch_epsilon(), 0.0008545, delta=1e-6)
+    self.assertAlmostEqual(fi.epsilon, 0.0008545, delta=1e-6)
 
-    sk_apriori_error = fi.get_sketch_epsilon() * wt
+    sk_apriori_error = fi.epsilon * wt
     reference_apriori_error = frequent_strings_sketch.get_apriori_error(k, wt)
     self.assertAlmostEqual(sk_apriori_error, reference_apriori_error, delta=1e-6)
 

--- a/tests/kll_test.py
+++ b/tests/kll_test.py
@@ -18,6 +18,7 @@
 import unittest
 from datasketches import kll_ints_sketch, kll_floats_sketch, kll_doubles_sketch
 from datasketches import kll_items_sketch, ks_test, PyStringsSerDe
+import copy
 import numpy as np
 
 class KllTest(unittest.TestCase):
@@ -57,20 +58,20 @@ class KllTest(unittest.TestCase):
       # and a few basic queries about the sketch
       self.assertFalse(kll.is_empty())
       self.assertTrue(kll.is_estimation_mode())
-      self.assertEqual(kll.get_n(), n)
-      self.assertEqual(kll.get_k(), k)
-      self.assertLess(kll.get_num_retained(), n)
+      self.assertEqual(kll.n, n)
+      self.assertEqual(kll.k, k)
+      self.assertLess(kll.num_retained, n)
 
       # merging itself will double the number of items the sketch has seen
       # but need to do that with a copy
-      kll_copy = kll_floats_sketch(kll)
+      kll_copy = copy.copy(kll)
       kll.merge(kll_copy)
-      self.assertEqual(kll.get_n(), 2*n)
+      self.assertEqual(kll.n, 2*n)
 
       # we can then serialize and reconstruct the sketch
       kll_bytes = kll.serialize()
       new_kll = kll_floats_sketch.deserialize(kll_bytes)
-      self.assertEqual(kll.get_num_retained(), new_kll.get_num_retained())
+      self.assertEqual(kll.num_retained, new_kll.num_retained)
       self.assertEqual(kll.get_min_value(), new_kll.get_min_value())
       self.assertEqual(kll.get_max_value(), new_kll.get_max_value())
       self.assertEqual(kll.get_quantile(0.7), new_kll.get_quantile(0.7))
@@ -86,7 +87,7 @@ class KllTest(unittest.TestCase):
         item = tuple[0]
         weight = tuple[1]
         total_weight = total_weight + weight
-      self.assertEqual(total_weight, kll.get_n())
+      self.assertEqual(total_weight, kll.n)
 
     def test_kll_ints_sketch(self):
         k = 100
@@ -97,10 +98,10 @@ class KllTest(unittest.TestCase):
 
         self.assertEqual(kll.get_min_value(), 0)
         self.assertEqual(kll.get_max_value(), n-1)
-        self.assertEqual(kll.get_n(), n)
+        self.assertEqual(kll.n, n)
         self.assertFalse(kll.is_empty())
         self.assertFalse(kll.is_estimation_mode()) # n < k
-        self.assertEqual(kll.get_k(), k)
+        self.assertEqual(kll.k, k)
 
         pmf = kll.get_pmf([round(n/2)])
         self.assertIsNotNone(pmf)
@@ -118,9 +119,9 @@ class KllTest(unittest.TestCase):
         self.assertEqual(kll.get_rank(round(n/2)), 0.5)
 
         # merge copy of self
-        kll_copy = kll_ints_sketch(kll)
+        kll_copy = copy.copy(kll)
         kll.merge(kll_copy)
-        self.assertEqual(kll.get_n(), 2 * n)
+        self.assertEqual(kll.n, 2 * n)
 
         sk_bytes = kll.serialize()
         self.assertTrue(isinstance(kll_ints_sketch.deserialize(sk_bytes), kll_ints_sketch))
@@ -148,15 +149,15 @@ class KllTest(unittest.TestCase):
         item = tuple[0]
         weight = tuple[1]
         total_weight = total_weight + weight
-      self.assertEqual(total_weight, kll.get_n())
+      self.assertEqual(total_weight, kll.n)
 
-      kll_copy = kll_items_sketch(kll)
+      kll_copy = copy.copy(kll)
       kll.merge(kll_copy)
-      self.assertEqual(kll.get_n(), 2 * n)
+      self.assertEqual(kll.n, 2 * n)
       
       kll_bytes = kll.serialize(PyStringsSerDe())
       new_kll = kll_items_sketch.deserialize(kll_bytes, PyStringsSerDe())
-      self.assertEqual(kll.get_num_retained(), new_kll.get_num_retained())
+      self.assertEqual(kll.num_retained, new_kll.num_retained)
       self.assertEqual(kll.get_min_value(), new_kll.get_min_value())
       self.assertEqual(kll.get_max_value(), new_kll.get_max_value())
       self.assertEqual(kll.get_quantile(0.7), new_kll.get_quantile(0.7))

--- a/tests/theta_test.py
+++ b/tests/theta_test.py
@@ -50,17 +50,17 @@ class ThetaTest(unittest.TestCase):
 
         count = 0
         for hash in new_sk:
-          self.assertLess(hash, new_sk.get_theta64())
+          self.assertLess(hash, new_sk.theta64)
           count = count + 1
-        self.assertEqual(count, new_sk.get_num_retained())
+        self.assertEqual(count, new_sk.num_retained)
 
-        num = sk.get_num_retained()
+        num = sk.num_retained
         sk.trim()
-        self.assertLessEqual(sk.get_num_retained(), num)
+        self.assertLessEqual(sk.num_retained, num)
 
         sk.reset()
         self.assertTrue(sk.is_empty())
-        self.assertEqual(sk.get_num_retained(), 0)
+        self.assertEqual(sk.num_retained, 0)
 
     def test_theta_set_operations(self):
         lgk = 12    # 2^k = 4096 rows in the table

--- a/tests/tuple_test.py
+++ b/tests/tuple_test.py
@@ -58,11 +58,11 @@ class TupleTest(unittest.TestCase):
         count = 0
         cumSum = 0
         for pair in new_sk:
-          self.assertLess(pair[0], new_sk.get_theta64())
+          self.assertLess(pair[0], new_sk.theta64)
           count += 1
           cumSum += pair[1]
-        self.assertEqual(count, new_sk.get_num_retained())
-        self.assertEqual(cumSum, 2 * new_sk.get_num_retained())
+        self.assertEqual(count, new_sk.num_retained)
+        self.assertEqual(cumSum, 2 * new_sk.num_retained)
 
         # we can even create a tuple sketch from an existing theta sketch
         # as long as we provide a summary to use
@@ -73,15 +73,15 @@ class TupleTest(unittest.TestCase):
         cumSum = 0
         for pair in cts:
           cumSum += pair[1]
-        self.assertEqual(cumSum, 5 * cts.get_num_retained())
+        self.assertEqual(cumSum, 5 * cts.num_retained)
 
-        num = sk.get_num_retained()
+        num = sk.num_retained
         sk.trim()
-        self.assertLessEqual(sk.get_num_retained(), num)
+        self.assertLessEqual(sk.num_retained, num)
 
         sk.reset()
         self.assertTrue(sk.is_empty())
-        self.assertEqual(sk.get_num_retained(), 0)
+        self.assertEqual(sk.num_retained, 0)
 
     def test_tuple_set_operations(self):
         lgk = 12    # 2^k = 4096 rows in the table
@@ -153,7 +153,7 @@ class TupleTest(unittest.TestCase):
             count5 += 1
           else:
             self.fail()
-        self.assertEqual(count5, result.get_num_retained())
+        self.assertEqual(count5, result.num_retained)
 
         # A NOT B
         # create an a_not_b object
@@ -175,7 +175,7 @@ class TupleTest(unittest.TestCase):
             count5 += 1
           else:
             self.fail()
-        self.assertEqual(count5, result.get_num_retained())
+        self.assertEqual(count5, result.num_retained)
 
         # JACCARD SIMILARITY
         # Jaccard Similarity measure returns (lower_bound, estimate, upper_bound)

--- a/tests/vector_of_kll_test.py
+++ b/tests/vector_of_kll_test.py
@@ -18,6 +18,7 @@
 import unittest
 from datasketches import (vector_of_kll_ints_sketches,
                           vector_of_kll_floats_sketches)
+import copy
 import numpy as np
 
 class VectorOfKllSketchesTest(unittest.TestCase):
@@ -72,7 +73,7 @@ class VectorOfKllSketchesTest(unittest.TestCase):
       self.assertEqual(result.n, d * n)
 
       # merging a copy of itself will double the number of items the sketch has seen
-      kll_copy = vector_of_kll_floats_sketches(kll)
+      kll_copy = copy.copy(kll)
       kll.merge(kll_copy)
       np.testing.assert_equal(kll.get_n(), 2*n)
 

--- a/tests/vector_of_kll_test.py
+++ b/tests/vector_of_kll_test.py
@@ -69,7 +69,7 @@ class VectorOfKllSketchesTest(unittest.TestCase):
 
       # we can combine sketches across all dimensions and get the result
       result = kll.collapse()
-      self.assertEqual(result.get_n(), d * n)
+      self.assertEqual(result.n, d * n)
 
       # merging a copy of itself will double the number of items the sketch has seen
       kll_copy = vector_of_kll_floats_sketches(kll)


### PR DESCRIPTION
API cleanup prior to a new release and some better docstrings.
* Use properties for basic sketch info (e.g. k, n, total_weight, num_retained)
* Use `__copy__` instead of C++-style copy constructors
* Add docstrings to all `__init__` statements
* Remove a few unnecessary ctors that would promote anti-patterns
