### PR TITLE
Expand docs

### DIFF
--- a/datasketches/KernelFunction.py
+++ b/datasketches/KernelFunction.py
@@ -24,8 +24,12 @@ from _datasketches import KernelFunction
 # Each implementation must extend the KernelFunction class
 # and define the __call__ method
 
-# Implements a basic Gaussian Kernel
 class GaussianKernel(KernelFunction):
+  '''Implements a basic Gaussian kernel
+
+     :param bandwidth: The kernel bandwidth, default 1.0
+     :type bandwidth: float
+    '''
   def __init__(self, bandwidth: float=1.0):
     KernelFunction.__init__(self)
     self._bw = bandwidth

--- a/datasketches/PySerDe.py
+++ b/datasketches/PySerDe.py
@@ -34,10 +34,10 @@ import struct
 
 class PyStringsSerDe(PyObjectSerDe):
   '''Implements a simple string-encoding scheme where a string is
-     written as <num_bytes> <string_contents>, with no null termination.
+     written as `<num_bytes> <string_contents>`, with no null termination.
      This format allows pre-allocating each string, at the cost of
      additional storage. Using this format, the serialized string consumes
-     4 + len(item) bytes.'''
+     ``4 + len(item)`` bytes.'''
   def get_size(self, item):
     return int(4 + len(item))
 

--- a/datasketches/PySerDe.py
+++ b/datasketches/PySerDe.py
@@ -32,12 +32,12 @@ import struct
 #     returns a tuple with the newly reconstructed object and the
 #     total number of bytes beyond the offset read from the input data.
 
-# Implements a simple string-encoding scheme where a string is
-# written as <num_bytes> <string_contents>, with no null termination.
-# This format allows pre-allocating each string, at the cost of
-# additional storage. Using this format, the serialized string consumes
-# 4 + len(item) bytes.
 class PyStringsSerDe(PyObjectSerDe):
+  '''Implements a simple string-encoding scheme where a string is
+     written as <num_bytes> <string_contents>, with no null termination.
+     This format allows pre-allocating each string, at the cost of
+     additional storage. Using this format, the serialized string consumes
+     4 + len(item) bytes.'''
   def get_size(self, item):
     return int(4 + len(item))
 
@@ -54,9 +54,9 @@ class PyStringsSerDe(PyObjectSerDe):
     str = data[offset+4:offset+4+num_chars].decode()
     return (str, 4+num_chars)
 
-# Implements an integer encoding scheme where each integer is written
-# as a 32-bit (4 byte) little-endian value.
 class PyIntsSerDe(PyObjectSerDe):
+  '''Implements an integer encoding scheme where each integer is written
+     as a 32-bit (4 byte) little-endian value.'''
   def get_size(self, item):
     return int(4)
 
@@ -68,9 +68,9 @@ class PyIntsSerDe(PyObjectSerDe):
     return (val, 4)
 
 
-# Implements an integer encoding scheme where each integer is written
-# as a 64-bit (8 byte) little-endian value.
 class PyLongsSerDe(PyObjectSerDe):
+  '''Implements an integer encoding scheme where each integer is written
+     as a 64-bit (8 byte) little-endian value.'''
   def get_size(self, item):
     return int(8)
 
@@ -82,9 +82,9 @@ class PyLongsSerDe(PyObjectSerDe):
     return (val, 8)
 
 
-# Implements a floating point encoding scheme where each value is written
-# as a 32-bit floating point value.
 class PyFloatsSerDe(PyObjectSerDe):
+  '''Implements a floating point encoding scheme where each value is written
+     as a 32-bit floating point value.'''
   def get_size(self, item):
     return int(4)
 
@@ -96,9 +96,9 @@ class PyFloatsSerDe(PyObjectSerDe):
     return (val, 4)
 
 
-# Implements a floating point encoding scheme where each value is written
-# as a 64-bit floating point value.
 class PyDoublesSerDe(PyObjectSerDe):
+  '''Implements a floating point encoding scheme where each value is written
+     as a 64-bit floating point value.'''
   def get_size(self, item):
     return int(8)
 

--- a/datasketches/TuplePolicy.py
+++ b/datasketches/TuplePolicy.py
@@ -22,16 +22,17 @@ from _datasketches import TuplePolicy
 # This file provides an example Python Tuple Policy implementation.
 #
 # Each implementation must extend the PyTuplePolicy class and define
-# two methods:
+# the following methods:
 #   * create_summary() returns a new Summary object
 #   * update_summary(summary, update) applies the relevant policy to update the
 #     provided summary with the data in update.
 #   * __call__ may be similar to update_summary but allows a different
 #     implementation for set operations (union and intersection)
 
-# Implements an accumulator summary policy, where new values are
-# added to the existing value.
 class AccumulatorPolicy(TuplePolicy):
+  '''Implements an accumulatory summary policy, where new values
+  are added to the existing value.'''
+
   def __init__(self):
     TuplePolicy.__init__(self)
 
@@ -47,8 +48,9 @@ class AccumulatorPolicy(TuplePolicy):
     return summary
 
 
-# Implements a MAX rule, where the largest integer value is always kept
 class MaxIntPolicy(TuplePolicy):
+  '''Implements a MAX rule, where the largest integer value is always kept.'''
+
   def __init__(self):
     TuplePolicy.__init__(self)
 
@@ -62,8 +64,9 @@ class MaxIntPolicy(TuplePolicy):
     return max(summary, update)
 
 
-# Implements a MIN rule, where the smallest integer value is always kept
 class MinIntPolicy(TuplePolicy):
+  '''Implements a MIN rule, where the smallest integer value is always kept.'''
+
   def __init__(self):
     TuplePolicy.__init__(self)
 

--- a/docs/source/count_min_sketch.rst
+++ b/docs/source/count_min_sketch.rst
@@ -17,7 +17,6 @@ heavy hitters.
     :members:
     :undoc-members:
     :exclude-members: deserialize, suggest_num_buckets, suggest_num_hashes
-    :member-order: groupwise
 
     .. rubric:: Static Methods:
 

--- a/docs/source/cpc.rst
+++ b/docs/source/cpc.rst
@@ -13,8 +13,7 @@ For additional security this sketch can be configured with a user-specified hash
 .. autoclass:: _datasketches.cpc_sketch
     :members:
     :undoc-members:
-    :exclude-members: deserialize,
-    :member-order: groupwise
+    :exclude-members: deserialize
 
     .. rubric:: Static Methods:
 
@@ -22,3 +21,12 @@ For additional security this sketch can be configured with a user-specified hash
 
     .. rubric:: Non-static Methods:
 
+    .. automethod:: __init__
+
+
+.. autoclass:: _datasketches.cpc_union
+    :members:
+    :undoc-members:
+    :exclude-members: deserialize
+
+    .. automethod:: __init__

--- a/docs/source/density_sketch.rst
+++ b/docs/source/density_sketch.rst
@@ -9,9 +9,21 @@ https://proceedings.mlr.press/v99/karnin19a/karnin19a.pdf
 
 Inspired by the following implementation: https://github.com/edoliberty/streaming-quantiles/blob/f688c8161a25582457b0a09deb4630a81406293b/gde.py
 
+Requires the use of a `KernelFunction` to compute the distance between two vectors.
+
+.. autoclass:: datasketches.KernelFunction
+    
+    .. automethod:: __call__
+
 .. autoclass:: datasketches.density_sketch
     :members:
     :undoc-members:
-    
-.. autoclass:: datasketches.GaussianKernel
-    :members:
+    :exclude-members: deserialize
+
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__

--- a/docs/source/density_sketch.rst
+++ b/docs/source/density_sketch.rst
@@ -1,5 +1,8 @@
 Density Sketch
 --------------
+
+.. currentmodule:: datasketches
+
 Builds a coreset from the given set of input points. 
 Provides density estimate at a given point.
 
@@ -9,13 +12,9 @@ https://proceedings.mlr.press/v99/karnin19a/karnin19a.pdf
 
 Inspired by the following implementation: https://github.com/edoliberty/streaming-quantiles/blob/f688c8161a25582457b0a09deb4630a81406293b/gde.py
 
-Requires the use of a `KernelFunction` to compute the distance between two vectors.
+Requires the use of a :class:`KernelFunction` to compute the distance between two vectors.
 
-.. autoclass:: datasketches.KernelFunction
-    
-    .. automethod:: __call__
-
-.. autoclass:: datasketches.density_sketch
+.. autoclass:: density_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize

--- a/docs/source/ebpps.rst
+++ b/docs/source/ebpps.rst
@@ -1,6 +1,8 @@
 Exact and Bounded, Probabilitiy Proportional to Size (EBPPS) Sampling
 ---------------------------------------------------------------------
 
+.. currentmodule:: datasketches
+
 An EBPPS sketch produces a randome sample of data from a stream of items, ensuring that the probability
 of including an item is always exactly equal to the item's size. The size of an item is defined as its
 weight relative to the total weight of all items seen so far by the sketch. In contrast to VarOpt sampling,
@@ -14,7 +16,10 @@ Information Processing Letters, 2023.
 EBPPS sampling is related to reservoir sampling, but handles unequal item weights.
 Feeding the sketch items with a uniform weight value will produce a sample equivalent to reservoir sampling.
 
-.. autoclass:: datasketches.ebpps_sketch
+.. note::
+    Serializing and deserializing this sketch requires the use of a :class:`PyObjectSerDe`.
+
+.. autoclass:: ebpps_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize

--- a/docs/source/ebpps.rst
+++ b/docs/source/ebpps.rst
@@ -1,0 +1,28 @@
+Exact and Bounded, Probabilitiy Proportional to Size (EBPPS) Sampling
+---------------------------------------------------------------------
+
+An EBPPS sketch produces a randome sample of data from a stream of items, ensuring that the probability
+of including an item is always exactly equal to the item's size. The size of an item is defined as its
+weight relative to the total weight of all items seen so far by the sketch. In contrast to VarOpt sampling,
+this sketch may return fewer than `k` items in order to keep the probability of including an item strictly
+proportional to its size.
+
+This sketch is based on: B. Hentschel, P. J. Haas, Y. Tian
+"Exact PPS Sampling with Bounded Sample Size",
+Information Processing Letters, 2023.
+
+EBPPS sampling is related to reservoir sampling, but handles unequal item weights.
+Feeding the sketch items with a uniform weight value will produce a sample equivalent to reservoir sampling.
+
+.. autoclass:: datasketches.ebpps_sketch
+    :members:
+    :undoc-members:
+    :exclude-members: deserialize
+
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__

--- a/docs/source/frequent_items.rst
+++ b/docs/source/frequent_items.rst
@@ -3,8 +3,8 @@ Frequent Items
 
 .. currentmodule:: datasketches
 
-This sketch is useful for tracking approximate frequencies of items of type `<T>` with optional associated counts `(<T> item, int count)` 
-that are members of a multiset of such items. 
+This sketch is useful for tracking approximate frequencies of items (``object`` or ``string``) with optional associated
+integer counts that are members of a multiset of such items. 
 The true frequency of an item is defined to be the sum of associated counts.
 
 This implementation provides the following capabilities:
@@ -23,18 +23,18 @@ The maximum map size is always a power of 2, defined through the variables ``lg_
 
 The hash map starts at a very small size (8 entries) and grows as needed up to the specified maximum map size.
 
-Excluding external space required for the item objects, the internal memory space usage of this sketch is `18 * ``mapSize`` bytes` (assuming 8 bytes for each reference), 
+Excluding external space required for the item objects, the internal memory space usage of this sketch is ``18 * mapSize`` bytes (assuming 8 bytes for each reference), 
 plus a small constant number of additional bytes. 
-The internal memory space usage of this sketch will never exceed `18 * ``maxMapSize`` ` bytes, plus a small constant number of additional bytes.
+The internal memory space usage of this sketch will never exceed ``18 * maxMapSize`` bytes, plus a small constant number of additional bytes.
 
 **Maximum Capacity of the Sketch**
 
 The ``LOAD_FACTOR`` for the hash map is internally set at :math:`75\%`, which means at any time the map capacity of ``(item, count)`` pairs is ``mapCap = 0.75 * mapSize``. 
-The maximum capacity of ``(item, count)`` pairs of the sketch is `maxMapCap = 0.75 * maxMapSize`.
+The maximum capacity of ``(item, count)`` pairs of the sketch is ``maxMapCap = 0.75 * maxMapSize``.
 
 **Updating the sketch with ``(item, count)`` pairs**
 
-If the item is found in the hash map, the mapped count field (the "counter") is incremented by the incoming count; otherwise, a new counter `"(item, count) pair"` is created. 
+If the item is found in the hash map, the mapped count field (the "counter") is incremented by the incoming count; otherwise, a new counter ``(item, count)`` pair is created. 
 If the number of tracked counters reaches the maximum capacity of the hash map, the sketch decrements all of the counters (by an approximately computed median) 
 and removes any non-positive counters.
 

--- a/docs/source/frequent_items.rst
+++ b/docs/source/frequent_items.rst
@@ -65,7 +65,18 @@ However, we have ensured that this probability is extremely small.
 For example, if the stream causes one table purge (rebuild), our proof of the worst-case bound applies with a probability of at least `1 - 1E-14`. 
 If the stream causes `1E9` purges, our proof applies with a probability of at least `1 - 1E-5`.
 
-Parameter: <T> The type of item to be tracked by this sketch
+There are two flavors of Frequent Items Sketches, one with generic items (objects) and another specific to strings.
+The string version is a legacy name from before the library supported generic objects and is retained
+only for backwards compatibility.
+
+
+.. autoclass:: _datasketches.frequent_items_error_type
+
+    .. autoattribute:: NO_FALSE_POSITIVES
+        :annotation: : Returns only true positives but may miss some heavy hitters.
+
+    .. autoattribute:: NO_FALSE_NEGATIVES
+        :annotation: : Does not miss any heavy hitters but may return false positives.
 
 
 .. autoclass:: _datasketches.frequent_items_sketch
@@ -81,3 +92,22 @@ Parameter: <T> The type of item to be tracked by this sketch
     .. automethod:: get_apriori_error
 
     .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__
+
+
+.. autoclass:: _datasketches.frequent_strings_sketch
+    :members:
+    :undoc-members:
+    :exclude-members: deserialize, get_epsilon_for_lg_size, get_apriori_error
+    :member-order: groupwise
+
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+    .. automethod:: get_epsilon_for_lg_size
+    .. automethod:: get_apriori_error
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__

--- a/docs/source/frequent_items.rst
+++ b/docs/source/frequent_items.rst
@@ -1,7 +1,7 @@
 Frequent Items
 --------------
 
-.. currentmodule:: dataskethches
+.. currentmodule:: datasketches
 
 This sketch is useful for tracking approximate frequencies of items of type `<T>` with optional associated counts `(<T> item, int count)` 
 that are members of a multiset of such items. 

--- a/docs/source/frequent_items.rst
+++ b/docs/source/frequent_items.rst
@@ -1,6 +1,8 @@
 Frequent Items
 --------------
 
+.. currentmodule:: dataskethches
+
 This sketch is useful for tracking approximate frequencies of items of type `<T>` with optional associated counts `(<T> item, int count)` 
 that are members of a multiset of such items. 
 The true frequency of an item is defined to be the sum of associated counts.
@@ -16,21 +18,21 @@ This implementation provides the following capabilities:
 
 **Space Usage**
 
-The sketch is initialized with a maximum map size, `maxMapSize`, that specifies the maximum physical length of the internal hash map of the form `(<T> item, int count)`. 
-The maximum map size is always a power of 2, defined through the variables `lg_max_map_size`.
+The sketch is initialized with a maximum map size, ``maxMapSize``, that specifies the maximum physical length of the internal hash map of the form ``(object item, int count)``. 
+The maximum map size is always a power of 2, defined through the variables ``lg_max_map_size``.
 
 The hash map starts at a very small size (8 entries) and grows as needed up to the specified maximum map size.
 
-Excluding external space required for the item objects, the internal memory space usage of this sketch is `18 * mapSize bytes` (assuming 8 bytes for each reference), 
+Excluding external space required for the item objects, the internal memory space usage of this sketch is `18 * ``mapSize`` bytes` (assuming 8 bytes for each reference), 
 plus a small constant number of additional bytes. 
-The internal memory space usage of this sketch will never exceed `18 * maxMapSize` bytes, plus a small constant number of additional bytes.
+The internal memory space usage of this sketch will never exceed `18 * ``maxMapSize`` ` bytes, plus a small constant number of additional bytes.
 
 **Maximum Capacity of the Sketch**
 
-The `LOAD_FACTOR` for the hash map is internally set at :math:`75\%`, which means at any time the map capacity of `(item, count)` pairs is `mapCap = 0.75 * mapSize`. 
-The maximum capacity of `(item, count)`` pairs of the sketch is `maxMapCap = 0.75 * maxMapSize`.
+The ``LOAD_FACTOR`` for the hash map is internally set at :math:`75\%`, which means at any time the map capacity of ``(item, count)`` pairs is ``mapCap = 0.75 * mapSize``. 
+The maximum capacity of ``(item, count)`` pairs of the sketch is `maxMapCap = 0.75 * maxMapSize`.
 
-**Updating the sketch with `(item, count)` pairs**
+**Updating the sketch with ``(item, count)`` pairs**
 
 If the item is found in the hash map, the mapped count field (the "counter") is incremented by the incoming count; otherwise, a new counter `"(item, count) pair"` is created. 
 If the number of tracked counters reaches the maximum capacity of the hash map, the sketch decrements all of the counters (by an approximately computed median) 
@@ -38,16 +40,16 @@ and removes any non-positive counters.
 
 **Accuracy**
 
-If fewer than `0.75 * maxMapSize` different items are inserted into the sketch, the estimated frequencies returned by the sketch will be exact.
+If fewer than ``0.75 * maxMapSize`` different items are inserted into the sketch, the estimated frequencies returned by the sketch will be exact.
 
 The logic of the frequent items sketch is such that the stored counts and true counts are never too different. 
 More specifically, for any item, the sketch can return an estimate of the true frequency of item, along with upper and lower bounds on the frequency (that hold deterministically).
 
 For this implementation and for a specific active item, it is guaranteed that the true frequency will be between the Upper Bound (UB) and the Lower Bound (LB) computed for that item. 
-Specifically, `(UB- LB) ≤ W * epsilon`, where :math:`W` denotes the sum of all item counts, and :math:`epsilon = 3.5/M`, where :math:`epsilon = M` is the maxMapSize.
+Specifically, ``(UB- LB) ≤ W * epsilon``, where :math:`W` denotes the sum of all item counts, and :math:`epsilon = 3.5/M`, where :math:`epsilon = M` is the maxMapSize.
 
 This is a worst-case guarantee that applies to arbitrary inputs.
-For inputs typically seen in practice, `(UB-LB)` is usually much smaller.
+For inputs typically seen in practice, ``(UB-LB)`` is usually much smaller.
 
 **Background**
 
@@ -63,14 +65,19 @@ Variants of it were discovered and rediscovered and redesigned several times ove
 For speed, we do employ some randomization that introduces a small probability that our proof of the worst-case bound might not apply to a given run. 
 However, we have ensured that this probability is extremely small. 
 For example, if the stream causes one table purge (rebuild), our proof of the worst-case bound applies with a probability of at least `1 - 1E-14`. 
-If the stream causes `1E9` purges, our proof applies with a probability of at least `1 - 1E-5`.
+If the stream causes ``1E9`` purges, our proof applies with a probability of at least ``1 - 1E-5``.
 
 There are two flavors of Frequent Items Sketches, one with generic items (objects) and another specific to strings.
 The string version is a legacy name from before the library supported generic objects and is retained
 only for backwards compatibility.
 
+.. note::
+    The :class:`frequent_items_sketch` uses an input object's ``__hash__`` and ``__eq__`` methods.
 
-.. autoclass:: _datasketches.frequent_items_error_type
+.. note::
+    Serializing and deserializing the :class:`frequent_items_sketch` requires the use of a :class:`PyObjectSerDe`.
+
+.. autoclass:: frequent_items_error_type
 
     .. autoattribute:: NO_FALSE_POSITIVES
         :annotation: : Returns only true positives but may miss some heavy hitters.
@@ -79,7 +86,7 @@ only for backwards compatibility.
         :annotation: : Does not miss any heavy hitters but may return false positives.
 
 
-.. autoclass:: _datasketches.frequent_items_sketch
+.. autoclass:: frequent_items_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize, get_epsilon_for_lg_size, get_apriori_error
@@ -96,7 +103,7 @@ only for backwards compatibility.
     .. automethod:: __init__
 
 
-.. autoclass:: _datasketches.frequent_strings_sketch
+.. autoclass:: frequent_strings_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize, get_epsilon_for_lg_size, get_apriori_error

--- a/docs/source/hyper_log_log.rst
+++ b/docs/source/hyper_log_log.rst
@@ -7,21 +7,28 @@ If the ONLY use case for sketching is counting uniques and merging, the HLL sket
 This implementation offers three different types of HLL sketch, each with different trade-offs with accuracy, space and performance. 
 These types are specified with the target_hll_type parameter.
 
-In terms of accuracy, all three types, for the same lg_config_k, have the same error distribution as a function of n, the number of unique values fed to the sketch.
-The configuration parameter `lg_config_k` is the log-base-2 of `K`, where `K` is the number of buckets or slots for the sketch.
+In terms of accuracy, all three types, for the same lg_config_k, have the same error distribution as a function of `n`, the number of unique values fed to the sketch.
+The configuration parameter `lg_config_k` is the log-base-2 of `k`, where `k`` is the number of buckets or slots for the sketch.
 
-During warmup, when the sketch has only received a small number of unique items (up to about 10% of `K`), this implementation leverages a new class of estimator algorithms with significantly better accuracy.
+During warmup, when the sketch has only received a small number of unique items (up to about 10% of `k`), this implementation leverages a new class of estimator algorithms with significantly better accuracy.
 
-This sketch also offers the capability of operating off-heap. 
-Given a WritableMemory object created by the user, the sketch will perform all of its updates and internal phase transitions in that object, which can actually reside either on-heap or off-heap based on how it is configured. 
-In large systems that must update and merge many millions of sketches, having the sketch operate off-heap avoids the serialization and deserialization costs of moving sketches to and from off-heap memory-mapped files, for example, and eliminates big garbage collection delays.
+
+.. autoclass:: _datasketches.tgt_hll_type
+
+    .. autoattribute:: HLL_4
+        :annotation: : 4 bits per entry
+
+    .. autoattribute:: HLL_6
+        :annotation: : 6 bits per entry
+
+    .. autoattribute:: HLL_8
+        :annotation: : 8 bits per entry
+
 
 .. autoclass:: _datasketches.hll_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize, get_max_updatable_serialization_bytes, get_rel_err 
-
-    :member-order: groupwise
 
     .. rubric:: Static Methods:
 
@@ -30,3 +37,19 @@ In large systems that must update and merge many millions of sketches, having th
     .. automethod:: get_rel_err
 
     .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__
+
+.. autoclass:: _datasketches.hll_union
+    :members:
+    :undoc-members:
+    :exclude-members: get_rel_err 
+
+    .. rubric:: Static Methods:
+
+    .. automethod:: get_rel_err
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__
+    

--- a/docs/source/hyper_log_log.rst
+++ b/docs/source/hyper_log_log.rst
@@ -7,10 +7,10 @@ If the ONLY use case for sketching is counting uniques and merging, the HLL sket
 This implementation offers three different types of HLL sketch, each with different trade-offs with accuracy, space and performance. 
 These types are specified with the target_hll_type parameter.
 
-In terms of accuracy, all three types, for the same lg_config_k, have the same error distribution as a function of `n`, the number of unique values fed to the sketch.
-The configuration parameter `lg_config_k` is the log-base-2 of `k`, where `k`` is the number of buckets or slots for the sketch.
+In terms of accuracy, all three types, for the same lg_config_k, have the same error distribution as a function of ``n``, the number of unique values fed to the sketch.
+The configuration parameter ``lg_config_k`` is the log-base-2 of ``k``, where ``k`` is the number of buckets or slots for the sketch.
 
-During warmup, when the sketch has only received a small number of unique items (up to about 10% of `k`), this implementation leverages a new class of estimator algorithms with significantly better accuracy.
+During warmup, when the sketch has only received a small number of unique items (up to about 10% of ``k``), this implementation leverages a new class of estimator algorithms with significantly better accuracy.
 
 
 .. autoclass:: _datasketches.tgt_hll_type

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -76,6 +76,7 @@ Helper Classes
    kernel
    jaccard
    tuple_policy
+   ks_test
 
 
 These classes are required for certain sketches or specific functionality withing sketches.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,6 +73,10 @@ Helper Classes
    :maxdepth: 1
 
    serde
+   kernel
+   jaccard
+   tuple_policy
+
 
 These classes are required for certain sketches or specific functionality withing sketches.
 Some of them are abstract base classes, but in those cases there is at least one reference example of a 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,7 +55,32 @@ Quantile Estimation
    kll
    req
    quantiles_depr
-   
+
+
+Random Sampling
+###############
+
+.. toctree::
+   :maxdepth: 1
+
+   varopt
+   ebpps
+
+Helper Classes
+##############
+
+.. toctree::
+   :maxdepth: 1
+
+   serde
+
+These classes are required for certain sketches or specific functionality withing sketches.
+Some of them are abstract base classes, but in those cases there is at least one reference example of a 
+concrete class.
+
+
+
+
 .. note::
 
    This project is under active development.
@@ -67,15 +92,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-
-
-.. .. automodule:: datasketches    
-..    :members:
-
-.. .. automodule:: _datasketches
-..     :members:
-
-.. 
-.. 
-
-..    distinct_count

--- a/docs/source/jaccard.rst
+++ b/docs/source/jaccard.rst
@@ -1,0 +1,23 @@
+Jaccard Similarity
+##################
+
+.. currentmodule:: datasketches
+
+These objects provide measures related to the `Jaccard similarity <https://en.wikipedia.org/wiki/Jaccard_similarity>`_
+of :class:`theta_sketch` and :class:`tuple_sketch` objects.
+
+Note that there are separate classes to be used for theta and tuple sketches.
+
+.. autoclass:: theta_jaccard_similarity
+
+  .. automethod:: jaccard
+  .. automethod:: exactly_equal
+  .. automethod:: similarity_test
+  .. automethod:: dissimilarity_test    
+
+.. autoclass:: tuple_jaccard_similarity
+
+  .. automethod:: jaccard
+  .. automethod:: exactly_equal
+  .. automethod:: similarity_test
+  .. automethod:: dissimilarity_test    

--- a/docs/source/kernel.rst
+++ b/docs/source/kernel.rst
@@ -1,0 +1,21 @@
+Kernel Function
+###############
+
+.. currentmodule:: datasketches
+
+A `kernel function <https://en.wikipedia.org/wiki/Positive-definite_kernel>`_ is a specific type of
+mathematical funciton that is particularly useful in certain machine learning and pattern recognition
+contexts. The :class:`density_sketch` performs approximate
+`kernel density estimation <https://en.wikipedia.org/wiki/Kernel_density_estimation>`_ which, unsurprisingly,
+relies on the use of such a kernel function.
+
+The library provides an abstract base class :class:`KernelFunction` and an example implementation of a
+Gaussian (also known as a Radial Basis Function) kernel. Custom classes must override the base class
+and provide a floating point value as a score indicating the similarity of two input vectors.
+
+.. autoclass:: KernelFunction
+    
+    .. automethod:: __call__
+
+.. autoclass:: GaussianKernel
+  :show-inheritance:

--- a/docs/source/kll.rst
+++ b/docs/source/kll.rst
@@ -104,21 +104,59 @@ Additionally, the interval may be quite large for certain distributions.
 - Then `q_lo ≤ q ≤ q_hi`, with 99% confidence.
 
 
-
-
 .. autoclass:: _datasketches.kll_ints_sketch
     :members:
     :undoc-members:
+    :exclude-members: deserialize, get_normalized_rank_error
+
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+    .. automethod:: get_normalized_rank_error
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__
 
 .. autoclass:: _datasketches.kll_floats_sketch
     :members:
     :undoc-members:
+    :exclude-members: deserialize, get_normalized_rank_error
+
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+    .. automethod:: get_normalized_rank_error
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__
 
 .. autoclass:: _datasketches.kll_doubles_sketch
     :members:
     :undoc-members:
+    :exclude-members: deserialize, get_normalized_rank_error
+
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+    .. automethod:: get_normalized_rank_error
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__
 
 .. autoclass:: _datasketches.kll_items_sketch
     :members:
     :undoc-members:
+    :exclude-members: deserialize, get_normalized_rank_error
+
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+    .. automethod:: get_normalized_rank_error
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__
 

--- a/docs/source/kll.rst
+++ b/docs/source/kll.rst
@@ -1,5 +1,8 @@
 KLL Sketch
 ----------
+
+.. currentmodule:: datasketches
+
 Implementation of a very compact quantiles sketch with lazy compaction scheme
 and nearly optimal accuracy per retained item.
 See `Optimal Quantile Approximation in Streams`.
@@ -106,7 +109,11 @@ Additionally, the interval may be quite large for certain distributions.
 .. note::
     For the :class:`kll_items_sketch`, objects must be comparable with ``__lt__``.
 
-.. autoclass:: _datasketches.kll_ints_sketch
+.. note::
+    Serializing and deserializing a :class:`kll_items_sketch` requires the use of a :class:`PyObjectSerDe`.
+
+
+.. autoclass:: kll_ints_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize, get_normalized_rank_error
@@ -120,7 +127,7 @@ Additionally, the interval may be quite large for certain distributions.
 
     .. automethod:: __init__
 
-.. autoclass:: _datasketches.kll_floats_sketch
+.. autoclass:: kll_floats_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize, get_normalized_rank_error
@@ -134,7 +141,7 @@ Additionally, the interval may be quite large for certain distributions.
 
     .. automethod:: __init__
 
-.. autoclass:: _datasketches.kll_doubles_sketch
+.. autoclass:: kll_doubles_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize, get_normalized_rank_error
@@ -148,7 +155,7 @@ Additionally, the interval may be quite large for certain distributions.
 
     .. automethod:: __init__
 
-.. autoclass:: _datasketches.kll_items_sketch
+.. autoclass:: kll_items_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize, get_normalized_rank_error

--- a/docs/source/kll.rst
+++ b/docs/source/kll.rst
@@ -103,6 +103,8 @@ Additionally, the interval may be quite large for certain distributions.
 - Let `q_hi = estimated quantile of rank (r + eps)`.
 - Then `q_lo ≤ q ≤ q_hi`, with 99% confidence.
 
+.. note::
+    For the :class:`kll_items_sketch`, objects must be comparable with ``__lt__``.
 
 .. autoclass:: _datasketches.kll_ints_sketch
     :members:

--- a/docs/source/ks_test.rst
+++ b/docs/source/ks_test.rst
@@ -1,0 +1,14 @@
+Kolmogorov-Smirnov Test
+#######################
+
+.. currentmodule:: datasketches
+
+A `Kolmogorov-Smirnov Test <https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test>`_` is
+a test of equality of two distributions to determine if they are likely to have come from the same
+underlying distribution.
+The DataSketches library provides a modified form of the test that takes into account the error
+in each underlying sketch in the analysis.
+
+Currently, the test assumes both input sketches are of the same family and data type.
+
+.. autofunction:: ks_test

--- a/docs/source/quantiles_depr.rst
+++ b/docs/source/quantiles_depr.rst
@@ -39,6 +39,9 @@ For example, the median item returned from `get_quantile(0.5)` will be between t
 from the hypothetically sorted array of input items at normalized ranks of 0.483 and 0.517, with
 a confidence of about 99%.
 
+.. note::
+    For the :class:`quantiles_items_sketch`, objects must be comparable with ``__lt__``.
+
 .. autoclass:: _datasketches.quantiles_ints_sketch
     :members:
     :undoc-members:

--- a/docs/source/quantiles_depr.rst
+++ b/docs/source/quantiles_depr.rst
@@ -1,6 +1,7 @@
 Quantiles Sketch (Deprecated)
 -----------------------------
 This is a deprecated quantiles sketch that is included for cross-language compatibility.
+Most new projects will favor the KLL sketch over this one.
 
 This is a stochastic streaming sketch that enables near-real time analysis of the
 approximate distribution from a very large stream in a single pass.
@@ -41,15 +42,55 @@ a confidence of about 99%.
 .. autoclass:: _datasketches.quantiles_ints_sketch
     :members:
     :undoc-members:
+    :exclude-members: deserialize, get_normalized_rank_error
+
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+    .. automethod:: get_normalized_rank_error
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__
 
 .. autoclass:: _datasketches.quantiles_floats_sketch
     :members:
     :undoc-members:
+    :exclude-members: deserialize, get_normalized_rank_error
+
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+    .. automethod:: get_normalized_rank_error
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__
 
 .. autoclass:: _datasketches.quantiles_doubles_sketch
     :members:
     :undoc-members:
+    :exclude-members: deserialize, get_normalized_rank_error
+
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+    .. automethod:: get_normalized_rank_error
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__
 
 .. autoclass:: _datasketches.quantiles_items_sketch
     :members:
     :undoc-members:
+    :exclude-members: deserialize, get_normalized_rank_error
+
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+    .. automethod:: get_normalized_rank_error
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__

--- a/docs/source/quantiles_depr.rst
+++ b/docs/source/quantiles_depr.rst
@@ -1,7 +1,11 @@
 Quantiles Sketch (Deprecated)
 -----------------------------
+
+.. currentmodule:: datasketches
+
 This is a deprecated quantiles sketch that is included for cross-language compatibility.
-Most new projects will favor the KLL sketch over this one.
+Most new projects will favor the KLL sketch over this one, or the REQ sketch for higher accuracy
+at the very edge of a distribution.
 
 This is a stochastic streaming sketch that enables near-real time analysis of the
 approximate distribution from a very large stream in a single pass.
@@ -42,7 +46,10 @@ a confidence of about 99%.
 .. note::
     For the :class:`quantiles_items_sketch`, objects must be comparable with ``__lt__``.
 
-.. autoclass:: _datasketches.quantiles_ints_sketch
+.. note::
+    Serializing and deserializing a :class:`quantiles_items_sketch` requires the use of a :class:`PyObjectSerDe`.
+
+.. autoclass:: quantiles_ints_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize, get_normalized_rank_error
@@ -56,7 +63,7 @@ a confidence of about 99%.
 
     .. automethod:: __init__
 
-.. autoclass:: _datasketches.quantiles_floats_sketch
+.. autoclass:: quantiles_floats_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize, get_normalized_rank_error
@@ -70,7 +77,7 @@ a confidence of about 99%.
 
     .. automethod:: __init__
 
-.. autoclass:: _datasketches.quantiles_doubles_sketch
+.. autoclass:: quantiles_doubles_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize, get_normalized_rank_error
@@ -84,7 +91,7 @@ a confidence of about 99%.
 
     .. automethod:: __init__
 
-.. autoclass:: _datasketches.quantiles_items_sketch
+.. autoclass:: quantiles_items_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize, get_normalized_rank_error

--- a/docs/source/req.rst
+++ b/docs/source/req.rst
@@ -1,5 +1,8 @@
 Relative Error Quantiles (REQ) Sketch
 -------------------------------------
+
+.. currentmodule:: datasketches
+
 This is an implementation based on the `paper <https://arxiv.org/abs/2004.01668>`_ "Relative Error Streaming Quantiles" by Graham Cormode, Zohar Karnin, Edo Liberty, Justin Thaler, Pavel Veselý, and loosely derived from a Python prototype written by Pavel Veselý.
 
 This implementation differs from the algorithm described in the paper in the following:
@@ -30,7 +33,10 @@ This is not only useful for debugging, but is a powerful tool to help users unde
 .. note::
     For the :class:`req_items_sketch`, objects must be comparable with ``__lt__``.
 
-.. autoclass:: _datasketches.req_ints_sketch
+.. note::
+    Serializing and deserializing a :class:`req_items_sketch` requires the use of a :class:`PyObjectSerDe`.
+
+.. autoclass:: req_ints_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize, get_RSE
@@ -44,7 +50,7 @@ This is not only useful for debugging, but is a powerful tool to help users unde
 
     .. automethod:: __init__
 
-.. autoclass:: _datasketches.req_floats_sketch
+.. autoclass:: req_floats_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize, get_RSE
@@ -58,7 +64,7 @@ This is not only useful for debugging, but is a powerful tool to help users unde
 
     .. automethod:: __init__
 
-.. autoclass:: _datasketches.req_items_sketch
+.. autoclass:: req_items_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize, get_RSE

--- a/docs/source/req.rst
+++ b/docs/source/req.rst
@@ -30,11 +30,41 @@ This is not only useful for debugging, but is a powerful tool to help users unde
 .. autoclass:: _datasketches.req_ints_sketch
     :members:
     :undoc-members:
+    :exclude-members: deserialize, get_RSE
+
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+    .. automethod:: get_RSE
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__
 
 .. autoclass:: _datasketches.req_floats_sketch
     :members:
     :undoc-members:
+    :exclude-members: deserialize, get_RSE
+
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+    .. automethod:: get_RSE
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__
 
 .. autoclass:: _datasketches.req_items_sketch
     :members:
     :undoc-members:
+    :exclude-members: deserialize, get_RSE
+
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+    .. automethod:: get_RSE
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__

--- a/docs/source/req.rst
+++ b/docs/source/req.rst
@@ -27,6 +27,9 @@ This implementation allows the user to use both the `INCLUSIVE` criterion and th
 This implementation provides extensive debug visibility into the operation of the sketch with two levels of detail output. 
 This is not only useful for debugging, but is a powerful tool to help users understand how the sketch works.
 
+.. note::
+    For the :class:`req_items_sketch`, objects must be comparable with ``__lt__``.
+
 .. autoclass:: _datasketches.req_ints_sketch
     :members:
     :undoc-members:

--- a/docs/source/serde.rst
+++ b/docs/source/serde.rst
@@ -1,0 +1,34 @@
+Serialize/Deserialize (SerDe)
+#############################
+
+.. currentmodule:: datasketches
+
+A SerDe is a class used to serialize items sketches to a :class:`bytes` object in binary.
+Several example SerDes are provided as references.
+
+The use of binary-compatible SerDes in different languages is critical for cross-language compatibility.
+
+Each implementation must extend the :class:`PyObjectSerDe` class and override all three of its methods.
+
+.. autoclass:: PyObjectSerDe
+  
+  .. automethod:: get_size
+  .. automethod:: to_bytes
+  .. automethod:: from_bytes
+
+
+The provided SerDes are:
+
+.. autoclass:: PyStringsSerDe
+  :show-inheritance:
+
+.. autoclass:: PyIntsSerDe
+  :show-inheritance:
+
+.. autoclass:: PyLongsSerDe
+  :show-inheritance:
+
+.. autoclass:: PyFloatsSerDe
+  :show-inheritance:
+
+.. autoclass:: PyDoublesSerDe

--- a/docs/source/theta.rst
+++ b/docs/source/theta.rst
@@ -1,5 +1,10 @@
 Theta Sketch
 ------------
+
+.. currentmodule:: datasketches
+
+Theta sketches are used for distinct counting.
+
 The theta package contains the basic sketch classes that are members of the `Theta Sketch Framework <https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html>`_.
 There is a separate Tuple package for many of the sketches that are derived from the same algorithms defined in the Theta Sketch Framework paper.
 
@@ -9,6 +14,52 @@ Theta sketch is a practical variant of the K-Minimum Values sketch which avoids 
 hash values on every insertion to the sketch.
 It has better error properties than the HyperLogLog sketch for set operations beyond the simple union.
 
-.. autoclass:: _datasketches.theta_sketch
+Set operations (union, intersection, A-not-B) are performed through the use of dedicated objects.
+
+Several `Jaccard similarity <https://en.wikipedia.org/wiki/Jaccard_similarity>`_
+measures can be computed between theta sketches with the :class:`theta_jaccard_similarity` class.
+
+.. autoclass:: theta_sketch
     :members:
     :undoc-members:
+    
+.. autoclass:: update_theta_sketch
+    :members:
+    :undoc-members:
+
+    .. automethod:: __init__
+
+
+.. autoclass:: compact_theta_sketch
+    :members:
+    :undoc-members:
+    :exclude-members: deserialize
+
+    .. rubric:: Static Methods:
+        
+    .. automethod:: deserialize
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__
+
+
+.. autoclass:: theta_union
+    :members:
+    :undoc-members:
+
+    .. automethod:: __init__
+
+
+.. autoclass:: theta_intersection
+    :members:
+    :undoc-members:
+
+    .. automethod:: __init__
+
+
+.. autoclass:: theta_a_not_b
+    :members:
+    :undoc-members:
+
+    .. automethod:: __init__

--- a/docs/source/tuple.rst
+++ b/docs/source/tuple.rst
@@ -1,18 +1,61 @@
 Tuple Sketch
 ------------
 
-Tuple sketches are an extension of Theta sketch that allow the keeping of arbitrary summaries associated with each retained key 
-(for example, a count for every key).
+.. currentmodule:: datasketches
 
-.. autoclass:: datasketches.tuple_sketch
+Tuple sketches are an extension of Theta sketches, meaning they provide estimate of distinct counts, that
+allow the keeping of arbitrary summaries associated with each retained key 
+(for example, a count for every key). The use of a :class:`tuple_sketch` requires a :class:`TuplePolicy` which
+defines how summaries are created, updated, merged, or intersected. The library provides a few basic 
+examples of :class:`TuplePolicy` implementations, but the right custom summary and policy can allow very
+complicated analysis to be performed quite easily.
+
+Set operations (union, intersection, A-not-B) are performed through the use of dedicated objects.
+
+Several `Jaccard similarity <https://en.wikipedia.org/wiki/Jaccard_similarity>`_
+measures can be computed between theta sketches with the :class:`tuple_jaccard_similarity` class.
+
+.. autoclass:: tuple_sketch
+    :members:
+    :undoc-members:
+    
+.. autoclass:: update_tuple_sketch
     :members:
     :undoc-members:
 
-.. autoclass:: datasketches.AccumulatorPolicy        
-    :members:    
+    .. automethod:: __init__
 
-.. autoclass:: datasketches.MaxIntPolicy        
-    :members:    
 
-.. autoclass:: datasketches.MinIntPolicy        
-    :members:    
+.. autoclass:: compact_tuple_sketch
+    :members:
+    :undoc-members:
+    :exclude-members: deserialize
+
+    .. rubric:: Static Methods:
+        
+    .. automethod:: deserialize
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__
+
+
+.. autoclass:: tuple_union
+    :members:
+    :undoc-members:
+
+    .. automethod:: __init__
+
+
+.. autoclass:: tuple_intersection
+    :members:
+    :undoc-members:
+
+    .. automethod:: __init__
+
+
+.. autoclass:: tuple_a_not_b
+    :members:
+    :undoc-members:
+
+    .. automethod:: __init__

--- a/docs/source/tuple.rst
+++ b/docs/source/tuple.rst
@@ -15,6 +15,9 @@ Set operations (union, intersection, A-not-B) are performed through the use of d
 Several `Jaccard similarity <https://en.wikipedia.org/wiki/Jaccard_similarity>`_
 measures can be computed between theta sketches with the :class:`tuple_jaccard_similarity` class.
 
+.. note::
+    Serializing and deserializing this sketch requires the use of a :class:`PyObjectSerDe`.
+
 .. autoclass:: tuple_sketch
     :members:
     :undoc-members:

--- a/docs/source/tuple_policy.rst
+++ b/docs/source/tuple_policy.rst
@@ -1,0 +1,25 @@
+Tuple Policy
+############
+
+.. currentmodule:: datasketches
+
+A Tuple Policy is needed when using a :class:`tuple_sketch` in order to specify how the 
+summary values should be created, updated, combined, or intersected. A summary can consist of
+any python object.
+
+Each implementation must extend the abstract base class :class:`TuplePolicy`.
+
+.. autoclass:: TuplePolicy
+  
+  .. automethod:: create_summary
+  .. automethod:: update_summary
+  .. automethod:: __call__
+
+.. autoclass:: AccumulatorPolicy
+  :show-inheritance:
+
+.. autoclass:: MinIntPolicy
+  :show-inheritance:
+
+.. autoclass:: MaxIntPolicy
+  :show-inheritance:

--- a/docs/source/varopt.rst
+++ b/docs/source/varopt.rst
@@ -1,6 +1,8 @@
 Variance Optimal Sampling (VarOpt)
 ----------------------------------
 
+.. currentmodule:: datasketches
+
 A VarOpt sketch samples data from a stream of items. The sketch is desinged for optimal (minimum)
 variance when querying the sketch to estimate subset sums of items matching a provided predicate.
 The sketch will produce a sample of size `k` (or smaller if fewer items have been presented), with
@@ -10,7 +12,10 @@ weight of all items presented to the sketch.
 VarOpt sampling is related to reservoir sampling, with improved error bounds for subset sum estimation.
 Feeding the sketch items with a uniform weight value will produce a sample equivalent to reservoir sampling.
 
-.. autoclass:: datasketches.var_opt_sketch
+.. note::
+    Serializing and deserializing this sketch requires the use of a :class:`PyObjectSerDe`.
+
+.. autoclass:: var_opt_sketch
     :members:
     :undoc-members:
     :exclude-members: deserialize
@@ -23,7 +28,7 @@ Feeding the sketch items with a uniform weight value will produce a sample equiv
 
     .. automethod:: __init__
 
-.. autoclass:: datasketches.var_opt_union
+.. autoclass:: var_opt_union
     :members:
     :undoc-members:
     :exclude-members: deserialize

--- a/docs/source/varopt.rst
+++ b/docs/source/varopt.rst
@@ -1,0 +1,37 @@
+Variance Optimal Sampling (VarOpt)
+----------------------------------
+
+A VarOpt sketch samples data from a stream of items. The sketch is desinged for optimal (minimum)
+variance when querying the sketch to estimate subset sums of items matching a provided predicate.
+The sketch will produce a sample of size `k` (or smaller if fewer items have been presented), with
+the probability of including an item roughly corresponding it the item's weight relative to the total
+weight of all items presented to the sketch.
+
+VarOpt sampling is related to reservoir sampling, with improved error bounds for subset sum estimation.
+Feeding the sketch items with a uniform weight value will produce a sample equivalent to reservoir sampling.
+
+.. autoclass:: datasketches.var_opt_sketch
+    :members:
+    :undoc-members:
+    :exclude-members: deserialize
+    
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__
+
+.. autoclass:: datasketches.var_opt_union
+    :members:
+    :undoc-members:
+    :exclude-members: deserialize
+    
+    .. rubric:: Static Methods:
+
+    .. automethod:: deserialize
+
+    .. rubric:: Non-static Methods:
+
+    .. automethod:: __init__

--- a/src/density_wrapper.cpp
+++ b/src/density_wrapper.cpp
@@ -108,11 +108,14 @@ void init_density(nb::module_ &m) {
 
   // generic kernel function
   nb::class_<kernel_function, KernelFunction>(m, "KernelFunction",
-     "KernelFunction provicdes a generic base class from which user-defined kernels must inherit. \
-     The class contains only a __call__ method that must be overridden.")
+     "A generic base class from which user-defined kernels must inherit.")
     .def(nb::init())
     .def("__call__", &kernel_function::operator(), nb::arg("a"), nb::arg("b"),
-     "A method to evaluate a kernel with given inputs a and b.")
+      "A method to evaluate a kernel with given inputs a and b.\n\n"
+      ":param a: An input vector\n:type a: numpy array\n"
+      ":param b: An input vector\n:type b: numpy array\n"
+      ":return: A vector similarity score\n:rtype: float"
+      )
     ;
 
   // the old sketch names can almost be defined, but the kernel_function_holder won't work in init()

--- a/src/fi_wrapper.cpp
+++ b/src/fi_wrapper.cpp
@@ -186,8 +186,8 @@ void init_fi(nb::module_ &m) {
   using namespace datasketches;
 
   nb::enum_<frequent_items_error_type>(m, "frequent_items_error_type")
-    .value("NO_FALSE_POSITIVES", NO_FALSE_POSITIVES)
-    .value("NO_FALSE_NEGATIVES", NO_FALSE_NEGATIVES)
+    .value("NO_FALSE_POSITIVES", NO_FALSE_POSITIVES, "Returns only true positives, but may miss some heavy hitters.")
+    .value("NO_FALSE_NEGATIVES", NO_FALSE_NEGATIVES, "Does not miss any heavy hitters, but may return false positives.")
     .export_values();
 
   bind_fi_sketch<std::string, uint64_t, std::hash<std::string>, std::equal_to<std::string>>(m, "frequent_strings_sketch");

--- a/src/ks_wrapper.cpp
+++ b/src/ks_wrapper.cpp
@@ -20,6 +20,7 @@
 #include "kolmogorov_smirnov.hpp"
 #include "kll_sketch.hpp"
 #include "quantiles_sketch.hpp"
+#include "py_object_lt.hpp"
 
 #include <nanobind/nanobind.h>
 
@@ -29,38 +30,50 @@ void init_kolmogorov_smirnov(nb::module_ &m) {
   using namespace datasketches;
 
   m.def("ks_test", &kolmogorov_smirnov::test<kll_sketch<int>>, nb::arg("sk_1"), nb::arg("sk_2"), nb::arg("p"),
-    "Performs the Kolmogorov-Smirnov Test between kll_ints_sketches.\n"
+    "Performs the Kolmogorov-Smirnov Test for :code:`kll_ints_sketch` pairs.\n"
     "Note: if the given sketches have insufficient data or if the sketch sizes are too small, "
     "this will return false.\n"
     "Returns True if we can reject the null hypothesis (that the sketches reflect the same underlying "
     "distribution) using the provided p-value, otherwise False.");
   m.def("ks_test", &kolmogorov_smirnov::test<kll_sketch<float>>, nb::arg("sk_1"), nb::arg("sk_2"), nb::arg("p"),
-    "Performs the Kolmogorov-Smirnov Test between kll_floats_sketches.\n"
+    "Performs the Kolmogorov-Smirnov Test for :code:`kll_floats_sketch` pairs.\n"
     "Note: if the given sketches have insufficient data or if the sketch sizes are too small, "
     "this will return false.\n"
     "Returns True if we can reject the null hypothesis (that the sketches reflect the same underlying "
     "distribution) using the provided p-value, otherwise False.");
   m.def("ks_test", &kolmogorov_smirnov::test<kll_sketch<double>>, nb::arg("sk_1"), nb::arg("sk_2"), nb::arg("p"),
-    "Performs the Kolmogorov-Smirnov Test between kll_doubles_sketches.\n"
+    "Performs the Kolmogorov-Smirnov Test for :code:`kll_doubles_sketch` pairs.\n"
+    "Note: if the given sketches have insufficient data or if the sketch sizes are too small, "
+    "this will return false.\n"
+    "Returns True if we can reject the null hypothesis (that the sketches reflect the same underlying "
+    "distribution) using the provided p-value, otherwise False.");
+  m.def("ks_test", &kolmogorov_smirnov::test<kll_sketch<nb::object, py_object_lt>>, nb::arg("sk_1"), nb::arg("sk_2"), nb::arg("p"),
+    "Performs the Kolmogorov-Smirnov Test for :code:`kll_items_sketch` pairs.\n"
     "Note: if the given sketches have insufficient data or if the sketch sizes are too small, "
     "this will return false.\n"
     "Returns True if we can reject the null hypothesis (that the sketches reflect the same underlying "
     "distribution) using the provided p-value, otherwise False.");
 
   m.def("ks_test", &kolmogorov_smirnov::test<quantiles_sketch<int>>, nb::arg("sk_1"), nb::arg("sk_2"), nb::arg("p"),
-    "Performs the Kolmogorov-Smirnov Test between quantiles_ints_sketches.\n"
+    "Performs the Kolmogorov-Smirnov Test for :code:`quantiles_ints_sketch` pairs.\n"
     "Note: if the given sketches have insufficient data or if the sketch sizes are too small, "
     "this will return false.\n"
     "Returns True if we can reject the null hypothesis (that the sketches reflect the same underlying "
     "distribution) using the provided p-value, otherwise False.");
   m.def("ks_test", &kolmogorov_smirnov::test<quantiles_sketch<float>>, nb::arg("sk_1"), nb::arg("sk_2"), nb::arg("p"),
-    "Performs the Kolmogorov-Smirnov Test between quantiles_floats_sketches.\n"
+    "Performs the Kolmogorov-Smirnov Test for :code:`quantiles_floats_sketch` pairs.\n"
     "Note: if the given sketches have insufficient data or if the sketch sizes are too small, "
     "this will return false.\n"
     ":Returns True if we can reject the null hypothesis (that the sketches reflect the same underlying "
     "distribution) using the provided p-value, otherwise False.");
   m.def("ks_test", &kolmogorov_smirnov::test<quantiles_sketch<double>>, nb::arg("sk_1"), nb::arg("sk_2"), nb::arg("p"),
-    "Performs the Kolmogorov-Smirnov Test between quantiles_doubles_sketches.\n"
+    "Performs the Kolmogorov-Smirnov Test for :code:`quantiles_doubles_sketch` pairs.\n"
+    "Note: if the given sketches have insufficient data or if the sketch sizes are too small, "
+    "this will return false.\n"
+    "Returns True if we can reject the null hypothesis (that the sketches reflect the same underlying "
+    "distribution) using the provided p-value, otherwise False.");
+  m.def("ks_test", &kolmogorov_smirnov::test<quantiles_sketch<nb::object, py_object_lt>>, nb::arg("sk_1"), nb::arg("sk_2"), nb::arg("p"),
+    "Performs the Kolmogorov-Smirnov Test for :code:`quantiles_items_sketch` pairs.\n"
     "Note: if the given sketches have insufficient data or if the sketch sizes are too small, "
     "this will return false.\n"
     "Returns True if we can reject the null hypothesis (that the sketches reflect the same underlying "

--- a/src/py_serde.cpp
+++ b/src/py_serde.cpp
@@ -32,12 +32,23 @@ void init_serde(nb::module_& m) {
     "An abstract base class for serde objects. All custom serdes must extend this class.")
     .def(nb::init<>())
     .def("get_size", &py_object_serde::get_size, nb::arg("item"),
-        "Returns the size in bytes of an item")
+        "Returns the size in bytes of an item\n\n"
+        ":param item: The specified object\n:type item: object\n"
+        ":return: The size of the item, in bytes\n:rtype: int"
+        )
     .def("to_bytes", &py_object_serde::to_bytes, nb::arg("item"),
-        "Retuns a bytes object with a serialized version of an item")
+        "Retuns a bytes object with a serialized version of an item\n\n"
+        ":param item: The specified object\n:type item: object\n"
+        ":return: A bytes object with the serialized object\n:rtype: bytes"
+        )
     .def("from_bytes", &py_object_serde::from_bytes, nb::arg("data"), nb::arg("offset"),
         "Reads a bytes object starting from the given offest and returns a tuple of the reconstructed "
-        "object and the number of additional bytes read")
+        "object and the number of additional bytes read\n\n"
+        ":param data: A bytes object to deserialize\n:type data: bytes\n"
+        ":param offset: The offset, in bytes, at which to start reading\n:type offset: int\n"
+        ":return: A tuple with the reconstructed object and the number of bytes read\n"
+        ":rtype: tuple(object, int)"
+        )
     ;
 }    
 

--- a/src/py_serde.cpp
+++ b/src/py_serde.cpp
@@ -34,19 +34,19 @@ void init_serde(nb::module_& m) {
     .def("get_size", &py_object_serde::get_size, nb::arg("item"),
         "Returns the size in bytes of an item\n\n"
         ":param item: The specified object\n:type item: object\n"
-        ":return: The size of the item, in bytes\n:rtype: int"
+        ":return: The size of the item in bytes\n:rtype: int"
         )
     .def("to_bytes", &py_object_serde::to_bytes, nb::arg("item"),
         "Retuns a bytes object with a serialized version of an item\n\n"
         ":param item: The specified object\n:type item: object\n"
-        ":return: A bytes object with the serialized object\n:rtype: bytes"
+        ":return: A :class:`bytes` object with the serialized object\n:rtype: bytes"
         )
     .def("from_bytes", &py_object_serde::from_bytes, nb::arg("data"), nb::arg("offset"),
         "Reads a bytes object starting from the given offest and returns a tuple of the reconstructed "
         "object and the number of additional bytes read\n\n"
-        ":param data: A bytes object to deserialize\n:type data: bytes\n"
+        ":param data: A :class:`bytes` object from which to deserialize\n:type data: bytes\n"
         ":param offset: The offset, in bytes, at which to start reading\n:type offset: int\n"
-        ":return: A tuple with the reconstructed object and the number of bytes read\n"
+        ":return: A :class:`tuple` with the reconstructed object and the number of bytes read\n"
         ":rtype: tuple(object, int)"
         )
     ;

--- a/src/theta_wrapper.cpp
+++ b/src/theta_wrapper.cpp
@@ -128,7 +128,7 @@ void init_theta(nb::module_ &m) {
         "Creates a theta_union using the provided parameters\n\n"
         ":param lg_k: base 2 logarithm of the maximum size of the union. Default 12.\n:type lg_k: int, optional\n"
         ":param p: an initial sampling rate to use. Default 1.0\n:type p: float, optional\n"
-        ":param seed: the seed to use when hashing values. Must match any sketch seeds.\n:type seed: int, optional"
+        ":param seed: the seed to use when hashing values. Must match all sketch seeds.\n:type seed: int, optional"
     )
     .def("update", &theta_union::update<const theta_sketch&>, nb::arg("sketch"),
          "Updates the union with the given sketch")
@@ -139,7 +139,7 @@ void init_theta(nb::module_ &m) {
   nb::class_<theta_intersection>(m, "theta_intersection")
     .def(nb::init<uint64_t>(), nb::arg("seed")=DEFAULT_SEED,
         "Creates a theta_intersection using the provided parameters\n\n"
-        ":param seed: the seed to use when hashing values. Must match any sketch seeds\n:type seed: int, optional"         
+        ":param seed: the seed to use when hashing values. Must match all sketch seeds\n:type seed: int, optional"         
     )
     .def("update", &theta_intersection::update<const theta_sketch&>, nb::arg("sketch"),
          "Intersections the provided sketch with the current intersection state")
@@ -152,7 +152,7 @@ void init_theta(nb::module_ &m) {
   nb::class_<theta_a_not_b>(m, "theta_a_not_b")
     .def(nb::init<uint64_t>(), nb::arg("seed")=DEFAULT_SEED,
         "Creates a tuple_a_not_b object\n\n"
-        ":param seed: the seed to use when hashing values. Must match any sketch seeds.\n:type seed: int, optional"
+        ":param seed: the seed to use when hashing values. Must match all sketch seeds.\n:type seed: int, optional"
     )
     .def(
         "compute",

--- a/src/tuple_wrapper.cpp
+++ b/src/tuple_wrapper.cpp
@@ -48,11 +48,22 @@ void init_tuple(nb::module_ &m) {
   nb::class_<tuple_policy, TuplePolicy>(m, "TuplePolicy",
      "An abstract base class for Tuple Policy objects. All custom policies must extend this class.")
     .def(nb::init())
-    .def("create_summary", &tuple_policy::create_summary, "Creates a new Summary object")
+    .def("create_summary", &tuple_policy::create_summary,
+         "Creates a new Summary object\n\n"
+         ":return: a Summary object\n:rtype: :class:`object`"
+         )
     .def("update_summary", &tuple_policy::update_summary, nb::arg("summary"), nb::arg("update"),
-         "applies the relevant policy to update the provided summary with the data in update.")
+         "Applies the relevant policy to update the provided summary with the data in update.\n\n"
+         ":param summary: An existing Summary\n:type summary: :class:`object`\n"
+         ":param update: An update to apply to the Summary\n:type update: :class:`object`\n"
+         ":return: The updated Summary\n:rtype: :class:`object`"
+         )
     .def("__call__", &tuple_policy::operator(), nb::arg("summary"), nb::arg("update"),
-         "Similar to update_summary but allows a different implementation for set operations (union and intersection)")
+         "Similar to update_summary but allows a different implementation for set operations (union and intersection)\n\n"
+         ":param summary: An existing Summary\n:type summary: :class:`object`\n"
+         ":param update: An update to apply to the Summary\n:type update: :class:`object`\n"
+         ":return: The updated Summary\n:rtype: :class:`object`"
+         )
   ;
 
   // potentially useful for debugging but not needed as a permanent

--- a/tests/kll_test.py
+++ b/tests/kll_test.py
@@ -163,6 +163,10 @@ class KllTest(unittest.TestCase):
       self.assertEqual(kll.get_quantile(0.7), new_kll.get_quantile(0.7))
       self.assertEqual(kll.get_rank(str(n/4)), new_kll.get_rank(str(n/4)))
 
+      # The sketches are identical so we cannot reject the null hypothesis that they
+      # reflect the same underlying distribtion
+      self.assertFalse(ks_test(kll, new_kll, 0.001))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/quantiles_test.py
+++ b/tests/quantiles_test.py
@@ -163,6 +163,10 @@ class QuantilesTest(unittest.TestCase):
       self.assertEqual(quantiles.get_quantile(0.7), new_quantiles.get_quantile(0.7))
       self.assertEqual(quantiles.get_rank(str(n/4)), new_quantiles.get_rank(str(n/4)))
 
+      # The sketches are identical so we cannot reject the null hypothesis that they
+      # reflect the same underlying distribtion
+      self.assertFalse(ks_test(quantiles, new_quantiles, 0.001))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Significant expansion of our documentation!

I also realized our kolmogorov-smirnov test didn't handle items sketches, so that's also fixed.  I added improved docstrings to the generic base classes so that those would show up nicer in IDEs and on the website.

The left rail on the rendered site is a little messy, but it's probably tolerable for now. However imperfect, I think this is still a big improvement.