### PR TITLE
Update build_wheels.yml

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -82,7 +82,7 @@ jobs:
           platforms: arm64
 
       - name: Install Python dependencies
-        run: python -m pip install cibuildwheel==2.12.0
+        run: python -m pip install cibuildwheel==2.16.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist


### PR DESCRIPTION
Use most recent cibuildwheel package, which will give us python 3.12 support: https://github.com/pypa/cibuildwheel#changelog