### PR TITLE
Build wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -5,6 +5,7 @@ on:
   
 env:
   BUILD_TYPE: Release
+  CIBUILDWHEEL_VERSION: 2.16.2
 
 jobs:
   build_sdist:
@@ -82,18 +83,13 @@ jobs:
           platforms: arm64
 
       - name: Install Python dependencies
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel>=${CIBUILDWHEEL_VERSION}
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
         env:
-          CIBW_ARCHS_LINUX: "auto aarch64"
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ENVIRONMENT_MACOS: CMAKE_OSX_ARCHITECTURES=${{ matrix.config.cibw-arch == 'macosx_x86_64' && 'x86_64' || matrix.config.cibw-arch == 'macosx_arm64' && 'arm64' || '' }}
           CIBW_BUILD: "*-${{ matrix.config.cibw-arch }}"
-          CIBW_BEFORE_BUILD_LINUX: "yum remove -y cmake"
-          CIBW_BEFORE_BUILD: "python -m pip install cmake>=3.18"
-          CIBW_SKIP: "*-win32 pp*-aarch64 pp*-macosx"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -5,7 +5,7 @@ on:
   
 env:
   BUILD_TYPE: Release
-  CIBUILDWHEEL_VERSION: 2.16.2
+  MIN_CIBUILDWHEEL_VERSION: 2.16.2
 
 jobs:
   build_sdist:
@@ -83,12 +83,11 @@ jobs:
           platforms: arm64
 
       - name: Install Python dependencies
-        run: python -m pip install cibuildwheel>=${{ env.CIBUILDWHEEL_VERSION }}
+        run: python -m pip install cibuildwheel~=${{ env.MIN_CIBUILDWHEEL_VERSION }}
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
         env:
-          #CIBW_ENVIRONMENT_MACOS: CMAKE_OSX_ARCHITECTURES=${{ matrix.config.cibw-arch == 'macosx_x86_64' && 'x86_64' || matrix.config.cibw-arch == 'macosx_arm64' && 'arm64' || '' }}
           CIBW_BUILD: "*-${{ matrix.config.cibw-arch }}"
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -83,7 +83,7 @@ jobs:
           platforms: arm64
 
       - name: Install Python dependencies
-        run: python -m pip install cibuildwheel>=${CIBUILDWHEEL_VERSION}
+        run: python -m pip install cibuildwheel>=${{ env.CIBUILDWHEEL_VERSION }}
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
         env:
-          CIBW_ENVIRONMENT_MACOS: CMAKE_OSX_ARCHITECTURES=${{ matrix.config.cibw-arch == 'macosx_x86_64' && 'x86_64' || matrix.config.cibw-arch == 'macosx_arm64' && 'arm64' || '' }}
+          #CIBW_ENVIRONMENT_MACOS: CMAKE_OSX_ARCHITECTURES=${{ matrix.config.cibw-arch == 'macosx_x86_64' && 'x86_64' || matrix.config.cibw-arch == 'macosx_arm64' && 'arm64' || '' }}
           CIBW_BUILD: "*-${{ matrix.config.cibw-arch }}"
 
       - uses: actions/upload-artifact@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ find_package(Python COMPONENTS Interpreter Development NumPy REQUIRED)
 endif()
 
 if(Python_VERSION VERSION_LESS "3.8")
-  message(FATAL_ERROR "DataSketches requires at least Python3.")
+  message(FATAL_ERROR "DataSketches requires at least Python3.8")
 endif()
 
 execute_process(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,5 +39,4 @@ before-build = "yum remove -y cmake"
 archs = ["x86_64", "arm64"]
 
 # Minimum version for proper C++17 support on MacOS
-[tool.cibuildwheel.macos.environment]
-MACOS_DEPLOYMENT_TARGET = "10.14"
+environment = { MACOSX_DEPLOYMENT_TARGET="10.14" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,4 +39,4 @@ before-build = "yum remove -y cmake"
 archs = ["x86_64", "arm64"]
 
 # Minimum version for proper C++17 support on MacOS
-environment = { MACOSX_DEPLOYMENT_TARGET="10.14" }
+environment = { MACOSX_DEPLOYMENT_TARGET=10.14 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 build-verbosity = 0  # options: 1, 2, or 3 
 skip = ["cp36-*", "cp37-*", "pp*", "*-win32"]
-#before-build = "python -m pip install cmake>=3.16"
 
 [tool.cibuildwheel.windows]
 archs = ["auto64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,25 @@
 requires = ["wheel",
             "setuptools >= 30.3.0",
             "cmake >= 3.16",
-            "numpy",
+            "numpy < 2.0",
             "nanobind >= 1.6"]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+build-verbosity = 0  # options: 1, 2, or 3 
+skip = ["cp36-*", "cp37-*", "pp*"]
+#before-build = "python -m pip install cmake>=3.16"
+
+[tool.cibuildwheel.windows]
+skip = "*-win32"
+
+[tool.cibuildwheel.linux]
+archs = ["auto", "aarch64"]
+before-build = "yum remove -y cmake"
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
+
+# Minimum version for proper C++17 support on MacOS
+[tool.cibuildwheel.macos.environment]
+MACOS_DEPLOYMENT_TARGET = "10.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ skip = ["cp36-*", "cp37-*", "pp*", "*-win32"]
 #before-build = "python -m pip install cmake>=3.16"
 
 [tool.cibuildwheel.windows]
-archs = ["win_amd64"]
+archs = ["auto64"]
 
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,4 +39,4 @@ before-build = "yum remove -y cmake"
 archs = ["x86_64", "arm64"]
 
 # Minimum version for proper C++17 support on MacOS
-environment = { MACOSX_DEPLOYMENT_TARGET=10.14 }
+environment-pass = [ "MACOSX_DEPLOYMENT_TARGET=10.14" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,11 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build-verbosity = 0  # options: 1, 2, or 3 
-skip = ["cp36-*", "cp37-*", "pp*"]
+skip = ["cp36-*", "cp37-*", "pp*", "*-win32"]
 #before-build = "python -m pip install cmake>=3.16"
 
 [tool.cibuildwheel.windows]
-skip = "*-win32"
+archs = ["win_amd64"]
 
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]
@@ -39,4 +39,4 @@ before-build = "yum remove -y cmake"
 archs = ["x86_64", "arm64"]
 
 # Minimum version for proper C++17 support on MacOS
-environment-pass = [ "MACOSX_DEPLOYMENT_TARGET=10.14" ]
+environment = { MACOSX_DEPLOYMENT_TARGET = "10.14" }


### PR DESCRIPTION
* Moved most of the cibuildwheel config options into pyproject.toml, so that they'll work if you try running cibuildwheel directly from the command line
* Improved dependency version management -- removed redundancy, used compatibility operator for cibuildwheel, and put the version specified near the top of the file
* Fixed typo in error message which left off an important minor version number