### PR TITLE
Fixes for problems found with 5.0.0-rc1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ execute_process(
 list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
 find_package(nanobind CONFIG REQUIRED)
 
-nanobind_add_module(python MODULE LTO STABLE_ABI NB_STATIC)
+nanobind_add_module(python MODULE LTO NOMINSIZE STABLE_ABI NB_STATIC)
 
 set_target_properties(python PROPERTIES
   PREFIX ""

--- a/include/kernel_function.hpp
+++ b/include/kernel_function.hpp
@@ -20,7 +20,8 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/trampoline.h>
 #include <nanobind/ndarray.h>
-#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/intrusive/counter.h>
+#include <nanobind/intrusive/ref.h>
 #include <nanobind/stl/vector.h>
 
 #include <numpy/arrayobject.h>
@@ -37,7 +38,7 @@ namespace datasketches {
  *        which native Python kernels ultimately inherit. The actual
  *        kernels implement KernelFunction, as shown in KernelFunction.py
  */
-struct kernel_function {
+struct kernel_function : public nb::intrusive_base {
   virtual double operator()(nb::handle& a, nb::handle& b) const = 0;
   virtual ~kernel_function() = default;
 };
@@ -71,7 +72,7 @@ struct KernelFunction : public kernel_function {
  * never need to use this directly.
  */
 struct kernel_function_holder {
-  explicit kernel_function_holder(std::shared_ptr<kernel_function> kernel) : _kernel(kernel) {}
+  explicit kernel_function_holder(kernel_function* kernel) : _kernel(kernel) {}
   kernel_function_holder(const kernel_function_holder& other) : _kernel(other._kernel) {}
   kernel_function_holder(kernel_function_holder&& other) : _kernel(std::move(other._kernel)) {}
   kernel_function_holder& operator=(const kernel_function_holder& other) { _kernel = other._kernel; return *this; }
@@ -99,7 +100,7 @@ struct kernel_function_holder {
   }
 
   private:
-    std::shared_ptr<kernel_function> _kernel;
+    nb::ref<kernel_function> _kernel;
 };
 
 }

--- a/include/tuple_policy.hpp
+++ b/include/tuple_policy.hpp
@@ -20,6 +20,8 @@
 #include <memory>
 #include <nanobind/nanobind.h>
 #include <nanobind/trampoline.h>
+#include <nanobind/intrusive/counter.h>
+#include <nanobind/intrusive/ref.h>
 
 #ifndef _TUPLE_POLICY_HPP_
 #define _TUPLE_POLICY_HPP_
@@ -33,10 +35,10 @@ namespace datasketches {
  *        which native Python policies ultimately inherit. The actual
  *        policies implement TuplePolicy, as shown in TuplePolicy.py
  */
-struct tuple_policy {
-  virtual nb::object create_summary() = 0;
-  virtual nb::object update_summary(nb::object& summary, const nb::object& update) = 0;
-  virtual nb::object operator()(nb::object& summary, const nb::object& update) = 0;
+struct tuple_policy : public nb::intrusive_base {
+  virtual nb::object create_summary() const = 0;
+  virtual nb::object update_summary(nb::object& summary, const nb::object& update) const = 0;
+  virtual nb::object operator()(nb::object& summary, const nb::object& update) const = 0;
   virtual ~tuple_policy() = default;
 };
 
@@ -53,7 +55,7 @@ struct TuplePolicy : public tuple_policy {
    * 
    * @return nb::object representing a new summary
    */
-  nb::object create_summary() override {
+  nb::object create_summary() const override {
     NB_OVERRIDE_PURE(
       create_summary,      // Name of function in C++ (must match Python name)
                            // Argument(s) -- if any
@@ -67,7 +69,7 @@ struct TuplePolicy : public tuple_policy {
    * @param update The new value with which to update the summary
    * @return nb::object The updated summary
    */
-  nb::object update_summary(nb::object& summary, const nb::object& update) override {
+  nb::object update_summary(nb::object& summary, const nb::object& update) const override {
     NB_OVERRIDE_PURE(
       update_summary,      // Name of function in C++ (must match Python name)
       summary, update      // Arguments
@@ -81,7 +83,7 @@ struct TuplePolicy : public tuple_policy {
    * @param update An update to apply to the current summary
    * @return nb::object The potentially modified summary
    */
-  nb::object operator()(nb::object& summary, const nb::object& update) override {
+  nb::object operator()(nb::object& summary, const nb::object& update) const override {
     NB_OVERRIDE_PURE_NAME(
       "__call__",          // Name of function in python
       operator(),          // Name of function in C++
@@ -96,7 +98,7 @@ struct TuplePolicy : public tuple_policy {
  * never need to use this directly.
  */
 struct tuple_policy_holder {
-  explicit tuple_policy_holder(std::shared_ptr<tuple_policy> policy) : _policy(policy) {}
+  explicit tuple_policy_holder(tuple_policy* policy) : _policy(policy) {}
   tuple_policy_holder(const tuple_policy_holder& other) : _policy(other._policy) {}
   tuple_policy_holder(tuple_policy_holder&& other) : _policy(std::move(other._policy)) {}
   tuple_policy_holder& operator=(const tuple_policy_holder& other) { _policy = other._policy; return *this; }
@@ -113,7 +115,7 @@ struct tuple_policy_holder {
   }
 
   private:
-    std::shared_ptr<tuple_policy> _policy;
+    nb::ref<tuple_policy> _policy;
 };
 
 /* A degenerate policy used to enable Jaccard Similarity on tuple sketches,

--- a/src/count_wrapper.cpp
+++ b/src/count_wrapper.cpp
@@ -50,7 +50,7 @@ void bind_count_min_sketch(nb::module_ &m, const char* name) {
                 "with 95% confidence, frequency estimates satisfy the 'relative_error' guarantee. "
                 "Returns the number of hash functions that are required in order to achieve the specified "
                 "confidence of the sketch. confidence = 1 - delta, with delta denoting the sketch failure probability.")
-    .def("__str__", &count_min_sketch<W>::to_string,
+    .def("__str__", [](const count_min_sketch<W>& sk) { return sk.to_string(); },
          "Produces a string summary of the sketch")
     .def("to_string", &count_min_sketch<W>::to_string,
          "Produces a string summary of the sketch")

--- a/src/cpc_wrapper.cpp
+++ b/src/cpc_wrapper.cpp
@@ -39,7 +39,7 @@ void init_cpc(nb::module_ &m) {
          ":type seed: int, optional"
     )
     .def("__copy__", [](const cpc_sketch& sk){ return cpc_sketch(sk); })
-    .def("__str__", &cpc_sketch::to_string,
+    .def("__str__", [](const cpc_sketch& sk) { return sk.to_string(); },
          "Produces a string summary of the sketch")
     .def("to_string", &cpc_sketch::to_string,
          "Produces a string summary of the sketch")

--- a/src/datasketches.cpp
+++ b/src/datasketches.cpp
@@ -18,6 +18,11 @@
  */
 
 #include <nanobind/nanobind.h>
+#include <nanobind/intrusive/counter.h>
+
+// needed for sketches such as Density and Tuple which rely
+// on a joint C++/Python object
+#include <nanobind/intrusive/counter.inl>
 
 namespace nb = nanobind;
 
@@ -41,6 +46,18 @@ void init_kolmogorov_smirnov(nb::module_& m);
 void init_serde(nb::module_& m);
 
 NB_MODULE(_datasketches, m) {
+  // needed in conjunction with the counter.inl include above
+  nb::intrusive_init(
+    [](PyObject *o) noexcept {
+        nb::gil_scoped_acquire guard;
+        Py_INCREF(o);
+    },
+    [](PyObject *o) noexcept {
+        nb::gil_scoped_acquire guard;
+        Py_DECREF(o);
+    }
+  );
+
   init_hll(m);
   init_kll(m);
   init_fi(m);

--- a/src/ebpps_wrapper.cpp
+++ b/src/ebpps_wrapper.cpp
@@ -39,7 +39,7 @@ void bind_ebpps_sketch(nb::module_ &m, const char* name) {
          ":param k: Maximum number of samples in the sketch\n:type k: int\n"
          )
     .def("__copy__", [](const ebpps_sketch<T>& sk){ return ebpps_sketch<T>(sk); })
-    .def("__str__", &ebpps_sketch<T>::to_string,
+    .def("__str__", [](const ebpps_sketch<T>& sk) { return sk.to_string(); },
          "Produces a string summary of the sketch")
     .def("to_string",
          [](const ebpps_sketch<T>& sk, bool print_items) {

--- a/src/fi_wrapper.cpp
+++ b/src/fi_wrapper.cpp
@@ -52,7 +52,7 @@ void bind_fi_sketch(nb::module_ &m, const char* name) {
          ":type lg_max_k: int\n"
          )
     .def("__copy__", [](const frequent_items_sketch<T, W, H, E>& sk){ return frequent_items_sketch<T,W,H,E>(sk); })
-    .def("__str__", &frequent_items_sketch<T, W, H, E>::to_string, nb::arg("print_items")=false,
+    .def("__str__", [](const frequent_items_sketch<T, W, H, E>& sk) { return sk.to_string(); },
          "Produces a string summary of the sketch")
     .def("to_string", &frequent_items_sketch<T, W, H, E>::to_string, nb::arg("print_items")=false,
          "Produces a string summary of the sketch")

--- a/src/hll_wrapper.cpp
+++ b/src/hll_wrapper.cpp
@@ -44,7 +44,7 @@ void init_hll(nb::module_ &m) {
          "HLL_8) at the cost of much higher initial memory use. Default (and recommended) is False.\n"
          ":type start_full_size: bool"
      )
-    .def("__str__", (std::string (hll_sketch::*)(bool,bool,bool,bool) const) &hll_sketch::to_string,
+    .def("__str__", [](const hll_sketch& sk) { return sk.to_string(); },
          "Produces a string summary of the sketch")
     .def("to_string", (std::string (hll_sketch::*)(bool,bool,bool,bool) const) &hll_sketch::to_string,
          nb::arg("summary")=true, nb::arg("detail")=false, nb::arg("aux_detail")=false, nb::arg("all")=false,

--- a/src/kll_wrapper.cpp
+++ b/src/kll_wrapper.cpp
@@ -47,7 +47,7 @@ void bind_kll_sketch(nb::module_ &m, const char* name) {
         "Updates the sketch with the given value")
     .def("merge", (void (kll_sketch<T, C>::*)(const kll_sketch<T, C>&)) &kll_sketch<T, C>::merge, nb::arg("sketch"),
         "Merges the provided sketch into this one")
-    .def("__str__", &kll_sketch<T, C>::to_string,
+    .def("__str__", [](const kll_sketch<T, C>& sk) { return sk.to_string(); },
         "Produces a string summary of the sketch")
     .def("to_string", &kll_sketch<T, C>::to_string, nb::arg("print_levels")=false, nb::arg("print_items")=false,
         "Produces a string summary of the sketch")

--- a/src/quantiles_wrapper.cpp
+++ b/src/quantiles_wrapper.cpp
@@ -52,7 +52,7 @@ void bind_quantiles_sketch(nb::module_ &m, const char* name) {
     )
     .def("merge", (void (quantiles_sketch<T, C>::*)(const quantiles_sketch<T, C>&)) &quantiles_sketch<T, C>::merge, nb::arg("sketch"),
          "Merges the provided sketch into this one")
-    .def("__str__", &quantiles_sketch<T, C>::to_string,
+    .def("__str__", [](const quantiles_sketch<T, C>& sk) { return sk.to_string(); },
          "Produces a string summary of the sketch")
     .def("to_string", &quantiles_sketch<T, C>::to_string, nb::arg("print_levels")=false, nb::arg("print_items")=false,
          "Produces a string summary of the sketch")

--- a/src/req_wrapper.cpp
+++ b/src/req_wrapper.cpp
@@ -49,7 +49,7 @@ void bind_req_sketch(nb::module_ &m, const char* name) {
         "Updates the sketch with the given value")
     .def("merge", (void (req_sketch<T, C>::*)(const req_sketch<T, C>&)) &req_sketch<T, C>::merge, nb::arg("sketch"),
         "Merges the provided sketch into this one")
-    .def("__str__", &req_sketch<T, C>::to_string,
+    .def("__str__", [](const req_sketch<T, C>& sk) { return sk.to_string(); },
         "Produces a string summary of the sketch")
     .def("to_string", &req_sketch<T, C>::to_string, nb::arg("print_levels")=false, nb::arg("print_items")=false,
         "Produces a string summary of the sketch")

--- a/src/theta_wrapper.cpp
+++ b/src/theta_wrapper.cpp
@@ -36,9 +36,9 @@ void init_theta(nb::module_ &m) {
   using namespace datasketches;
 
   nb::class_<theta_sketch>(m, "theta_sketch", "An abstract base class for theta sketches")
-    .def("__str__", &theta_sketch::to_string, nb::arg("print_items")=false,
+    .def("__str__", [](const theta_sketch& sk) { return sk.to_string(); },
          "Produces a string summary of the sketch")
-    .def("to_string", &theta_sketch::to_string, nb::arg("print_items")=false,
+    .def("to_string", [](const theta_sketch& sk, bool print_items) { return sk.to_string(print_items); }, nb::arg("print_items")=false,
          "Produces a string summary of the sketch")
     .def("is_empty", static_cast<bool (theta_sketch::*)() const>(&theta_sketch::is_empty),
          "Returns True if the sketch is empty, otherwise False")

--- a/src/vector_of_kll.cpp
+++ b/src/vector_of_kll.cpp
@@ -539,11 +539,11 @@ void bind_vector_of_kll_sketches(nb::module_ &m, const char* name) {
     .def("update", &vector_of_kll_sketches<T>::update, nb::arg("items"), nb::arg("order") = "C",
          "Updates the sketch(es) with value(s).  Must be a 1D array of size equal to the number of sketches.  Can also be 2D array of shape (n_updates, n_sketches).  If a sketch does not have a value to update, use np.nan. "
          " Order 'F' specifies a column-major (Fortran style) matrix; any other value assumes row-major (C style) matrix.")
-    .def("__str__", &vector_of_kll_sketches<T>::to_string, nb::arg("print_levels")=false, nb::arg("print_items")=false,
-         "Produces a string summary of all sketches. Users should split the returned string by '\n\n'")
+    .def("__str__", [](const vector_of_kll_sketches<T>& sk) { return sk.to_string(); },
+         "Produces a string summary of all sketches. Users should split the returned string by '\\n\\n'")
     .def("to_string", &vector_of_kll_sketches<T>::to_string, nb::arg("print_levels")=false,
                                                              nb::arg("print_items")=false,
-         "Produces a string summary of all sketches. Users should split the returned string by '\n\n'")
+         "Produces a string summary of all sketches. Users should split the returned string by '\\n\\n'")
     .def("is_empty", &vector_of_kll_sketches<T>::is_empty,
          "Returns whether the sketch(es) is(are) empty of not")
     .def("get_n", &vector_of_kll_sketches<T>::get_n, 

--- a/src/vo_wrapper.cpp
+++ b/src/vo_wrapper.cpp
@@ -40,7 +40,7 @@ void bind_vo_sketch(nb::module_ &m, const char* name) {
          ":param k: Maximum number of samples in the sketch\n:type k: int\n"
     )
     .def("__copy__", [](const var_opt_sketch<T>& sk){ return var_opt_sketch<T>(sk); })
-    .def("__str__", &var_opt_sketch<T>::to_string,
+    .def("__str__", [](const var_opt_sketch<T>& sk) { return sk.to_string(); },
          "Produces a string summary of the sketch")
     .def("to_string",
          [](const var_opt_sketch<T>& sk, bool print_items) {
@@ -105,7 +105,7 @@ void bind_vo_union(nb::module_ &m, const char* name) {
 
   nb::class_<var_opt_union<T>>(m, name)
     .def(nb::init<uint32_t>(), nb::arg("max_k"))
-    .def("__str__", &var_opt_union<T>::to_string,
+    .def("__str__", [](const var_opt_union<T>& sk) { return sk.to_string(); },
          "Produces a string summary of the sketch")
     .def("to_string", &var_opt_union<T>::to_string,
          "Produces a string summary of the sketch")

--- a/tests/count_min_test.py
+++ b/tests/count_min_test.py
@@ -82,5 +82,9 @@ class CountMinTest(unittest.TestCase):
     for i in range(0, 2 * n):
       self.assertEqual(cm.get_estimate(i), new_cm.get_estimate(i))
 
+    # finally just check that printing works as expected
+    self.assertGreater(len(cm.to_string()), 0)
+    self.assertEqual(len(cm.__str__()), len(cm.to_string()))
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cpc_test.py
+++ b/tests/cpc_test.py
@@ -60,6 +60,10 @@ class CpcTest(unittest.TestCase):
     new_cpc = cpc_sketch.deserialize(sk_bytes)
     self.assertFalse(new_cpc.is_empty())
 
+    # finally just check that printing works as expected
+    self.assertGreater(len(cpc.to_string()), 0)
+    self.assertEqual(len(cpc.__str__()), len(cpc.to_string()))
+
   def test_cpc_get_lg_k(self):
     lgk = 10
     cpc = cpc_sketch(lgk)

--- a/tests/density_test.py
+++ b/tests/density_test.py
@@ -61,6 +61,10 @@ class densityTest(unittest.TestCase):
     sketch2 = density_sketch.deserialize(sk_bytes, GaussianKernel())
     self.assertEqual(sketch.get_estimate([1.5, 2.5, 3.5]), sketch2.get_estimate([1.5, 2.5, 3.5]))
 
+    # check that printing works as expected
+    self.assertGreater(len(sketch.to_string(True, True)), 0)
+    self.assertEqual(len(sketch.__str__()), len(sketch.to_string()))
+
   def test_density_merge(self):
     sketch1 = density_sketch(10, 2, GaussianKernel())
     sketch1.update([0, 0])

--- a/tests/ebpps_test.py
+++ b/tests/ebpps_test.py
@@ -109,5 +109,9 @@ class EbppsTest(unittest.TestCase):
     self.assertEqual(sk.c, rebuilt.c)
     self.assertEqual(sk.n, rebuilt.n)
 
+    # check that printing works as expected
+    self.assertGreater(len(sk.to_string(True)), 0)
+    self.assertEqual(len(sk.__str__()), len(sk.to_string()))
+
 if __name__ == '__main__':
   unittest.main()

--- a/tests/fi_test.py
+++ b/tests/fi_test.py
@@ -132,6 +132,9 @@ class FiTest(unittest.TestCase):
     self.assertGreater(new_fi.num_active_items, 0)
     self.assertEqual(5 * wt, new_fi.total_weight)
 
+    # check that printing works as expected
+    self.assertGreater(len(fi.to_string(True)), 0)
+    self.assertEqual(len(fi.__str__()), len(fi.to_string()))
 
   def test_fi_sketch(self):
     # only testing a few things not used in the above example

--- a/tests/hll_test.py
+++ b/tests/hll_test.py
@@ -67,6 +67,10 @@ class HllTest(unittest.TestCase):
         new_hll.reset()
         self.assertTrue(new_hll.is_empty())
 
+        # check that printing works as expected
+        self.assertGreater(len(hll.to_string(True, True, True, True)), 0)
+        self.assertEqual(len(hll.__str__()), len(hll.to_string()))
+
     def test_hll_sketch(self):
         lgk = 8
         n = 117

--- a/tests/kll_test.py
+++ b/tests/kll_test.py
@@ -167,6 +167,9 @@ class KllTest(unittest.TestCase):
       # reflect the same underlying distribtion
       self.assertFalse(ks_test(kll, new_kll, 0.001))
 
+      # check that printing works as expected
+      self.assertGreater(len(kll.to_string(True, True)), 0)
+      self.assertEqual(len(kll.__str__()), len(kll.to_string()))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/quantiles_test.py
+++ b/tests/quantiles_test.py
@@ -167,6 +167,9 @@ class QuantilesTest(unittest.TestCase):
       # reflect the same underlying distribtion
       self.assertFalse(ks_test(quantiles, new_quantiles, 0.001))
 
+      # check that printing works as expected
+      self.assertGreater(len(quantiles.to_string(True, True)), 0)
+      self.assertEqual(len(quantiles.__str__()), len(quantiles.to_string()))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/req_test.py
+++ b/tests/req_test.py
@@ -162,6 +162,9 @@ class reqTest(unittest.TestCase):
       self.assertEqual(req.get_quantile(0.7), new_req.get_quantile(0.7))
       self.assertEqual(req.get_rank(str(n/4)), new_req.get_rank(str(n/4)))
 
+      # check that printing works as expected
+      self.assertGreater(len(req.to_string(True, True)), 0)
+      self.assertEqual(len(req.__str__()), len(req.to_string()))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/theta_test.py
+++ b/tests/theta_test.py
@@ -48,6 +48,10 @@ class ThetaTest(unittest.TestCase):
         self.assertFalse(sk.is_empty())
         self.assertEqual(sk.get_estimate(), new_sk.get_estimate())
 
+        # check that printing works as expected
+        self.assertGreater(len(sk.to_string(True)), 0)
+        self.assertEqual(len(sk.__str__()), len(sk.to_string()))
+
         count = 0
         for hash in new_sk:
           self.assertLess(hash, new_sk.theta64)

--- a/tests/tuple_test.py
+++ b/tests/tuple_test.py
@@ -75,6 +75,10 @@ class TupleTest(unittest.TestCase):
           cumSum += pair[1]
         self.assertEqual(cumSum, 5 * cts.num_retained)
 
+        # check that printing works as expected
+        self.assertGreater(len(sk.to_string(True)), 0)
+        self.assertEqual(len(sk.__str__()), len(sk.to_string()))
+
         num = sk.num_retained
         sk.trim()
         self.assertLessEqual(sk.num_retained, num)

--- a/tests/vector_of_kll_test.py
+++ b/tests/vector_of_kll_test.py
@@ -127,6 +127,11 @@ class VectorOfKllSketchesTest(unittest.TestCase):
       np.testing.assert_allclose(kll.get_min_values(), smin)
       np.testing.assert_allclose(kll.get_max_values(), smax)
 
+      # check that printing works as expected
+      self.assertGreater(len(kll.to_string(True, True)), 0)
+      self.assertEqual(len(kll.__str__()), len(kll.to_string()))
+
+
     def test_kll_3Dupdates(self):
       # now test 3D update, which should fail
       k = 200

--- a/tests/vo_test.py
+++ b/tests/vo_test.py
@@ -128,5 +128,14 @@ class VoTest(unittest.TestCase):
     self.assertEqual(summary1['estimate'], summary2['estimate'])
     self.assertEqual(summary1['total_sketch_weight'], summary2['total_sketch_weight'])
 
+    # check that printing works as expected
+    self.assertGreater(len(result.to_string(True)), 0)
+    self.assertEqual(len(result.__str__()), len(result.to_string()))
+
+    self.assertGreater(len(union.to_string()), 0)
+    self.assertEqual(len(union.__str__()), len(union.to_string()))
+
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
3 main changes:
* Fix dual C++/Python object handling in tuple and density to avoid leaking objects
* Ensure `__str__` method always calls default `to_string()` and cannot accept parameters
* Add explicit tests of `to_string()` and `__str__` to all tests
* `NOMINSIZE` in CMakeLists.txt to override Nanobind's `-Os` compiler flag

I'm not sure why a regular call to &sketch_type::to_string sometimes fails. Maybe I need to cast the the right type? But in a few places I used a lambda when it dind't seem necessary just because it worked.

If this looks good, I'll cherry-pick it into the 5.0.x branch.