### PR TITLE
Use numpy's import_array1(0) to avoid return type weirdness

### DIFF
--- a/src/density_wrapper.cpp
+++ b/src/density_wrapper.cpp
@@ -98,7 +98,7 @@ void bind_density_sketch(nb::module_ &m, const char* name) {
 }
 
 int prepare_numpy() {
-  import_array();
+  import_array1(0);
   return 0;
 }
 


### PR DESCRIPTION
This affected alpine linux (a lightweight image commonly used in docker builds) due to its use of muslinux, for which we don't have pre-compiled wheels.

This should fix issue #43