### PR TITLE
Musllinux wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -53,13 +53,11 @@ jobs:
             name: "Ubuntu Latest (x86_64, manylinux)",
             os: ubuntu-latest,
             cibw-arch: manylinux_x86_64,
-            CIBW_BEFORE_BUILD: "yum remove -y cmake"
           }
         - {
             name: "Ubuntu Latest (ARM64, manylinux)",
             os: ubuntu-latest,
             cibw-arch: manylinux_aarch64,
-            CIBW_BEFORE_BUILD: "yum remove -y cmake",
             use-qemu: true
           }
         - {

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -2,7 +2,7 @@ name: Build Python Wheels
 
 on:
   workflow_dispatch:
-  
+
 env:
   BUILD_TYPE: Release
   MIN_CIBUILDWHEEL_VERSION: 2.16.2
@@ -50,20 +50,26 @@ jobs:
             cibw-arch: macosx_arm64
           }
         - {
-            name: "Ubuntu Latest (x86_64)",
+            name: "Ubuntu Latest (x86_64, manylinux)",
             os: ubuntu-latest,
             cibw-arch: manylinux_x86_64
           }
         - {
-            name: "Ubuntu Latest (ARM64)",
+            name: "Ubuntu Latest (ARM64, manylinux)",
             os: ubuntu-latest,
             cibw-arch: manylinux_aarch64,
             use-qemu: true
           }
         - {
-            name: "Ubuntu Latest (i686)",
+            name: "Ubuntu Latest (x86_64, muslinux)",
             os: ubuntu-latest,
-            cibw-arch: manylinux_i686
+            cibw-arch: muslinux_x86_64
+          }
+        - {
+            name: "Ubuntu Latest (ARM64, muslinux)",
+            os: ubuntu-latest,
+            cibw-arch: muslinux_aarch64,
+            use-qemu: true
           }
         - {
             name: "Windows Latest",

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -52,12 +52,14 @@ jobs:
         - {
             name: "Ubuntu Latest (x86_64, manylinux)",
             os: ubuntu-latest,
-            cibw-arch: manylinux_x86_64
+            cibw-arch: manylinux_x86_64,
+            CIBW_BEFORE_BUILD: "yum remove -y cmake"
           }
         - {
             name: "Ubuntu Latest (ARM64, manylinux)",
             os: ubuntu-latest,
             cibw-arch: manylinux_aarch64,
+            CIBW_BEFORE_BUILD: "yum remove -y cmake",
             use-qemu: true
           }
         - {

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -61,14 +61,14 @@ jobs:
             use-qemu: true
           }
         - {
-            name: "Ubuntu Latest (x86_64, muslinux)",
+            name: "Ubuntu Latest (x86_64, musllinux)",
             os: ubuntu-latest,
-            cibw-arch: muslinux_x86_64
+            cibw-arch: musllinux_x86_64
           }
         - {
-            name: "Ubuntu Latest (ARM64, muslinux)",
+            name: "Ubuntu Latest (ARM64, musllinux)",
             os: ubuntu-latest,
-            cibw-arch: muslinux_aarch64,
+            cibw-arch: musllinux_aarch64,
             use-qemu: true
           }
         - {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ skip = ["cp36-*", "cp37-*", "pp*", "*-win32"]
 [tool.cibuildwheel.windows]
 archs = ["auto64"]
 
-#[tool.cibuildwheel.linux]
-#archs = ["auto", "aarch64"]
+[tool.cibuildwheel.linux]
+archs = ["auto", "aarch64"]
 #before-build = "yum remove -y cmake"
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires = ["wheel",
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-build-verbosity = 0  # options: 1, 2, or 3 
+build-verbosity = 0  # options: 1, 2, or 3
 skip = ["cp36-*", "cp37-*", "pp*", "*-win32"]
 
 [tool.cibuildwheel.windows]
@@ -33,6 +33,10 @@ archs = ["auto64"]
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]
 before-build = "yum remove -y cmake"
+
+[[tool.cibuildwheel.overrides]]
+select = "*muslllinux*"
+before-build = ""
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,9 @@ skip = ["cp36-*", "cp37-*", "pp*", "*-win32"]
 [tool.cibuildwheel.windows]
 archs = ["auto64"]
 
-[tool.cibuildwheel.linux]
-archs = ["auto", "aarch64"]
-before-build = "yum remove -y cmake"
-
-[[tool.cibuildwheel.overrides]]
-select = "*muslllinux*"
-before-build = ""
+#[tool.cibuildwheel.linux]
+#archs = ["auto", "aarch64"]
+#before-build = "yum remove -y cmake"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ archs = ["auto64"]
 
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]
-#before-build = "yum remove -y cmake"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
Also removed 32-bit wheel builds (can still build from source) and an option to remove the built-in cmake -- I think that was useful when we briefly required a newer-than-standard version. But now the standard version has caught up and surpassed our minimum requirement.