### PR TITLE
Fix test to remove deprecated call, allow use of numpy 1.x or 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@
 requires = ["wheel",
             "setuptools >= 30.3.0",
             "cmake >= 3.16",
-            "numpy < 2.0",
+            "numpy",
             "nanobind >= 1.6"]
 build-backend = "setuptools.build_meta"
 

--- a/tests/vector_of_kll_test.py
+++ b/tests/vector_of_kll_test.py
@@ -114,8 +114,8 @@ class VectorOfKllSketchesTest(unittest.TestCase):
 
       for i in range(0, n):
         dat  = np.random.randn(nbatch, d)
-        smin = np.amin(np.row_stack((smin, dat)), axis=0)
-        smax = np.amax(np.row_stack((smax, dat)), axis=0)
+        smin = np.amin(np.vstack((smin, dat)), axis=0)
+        smax = np.amax(np.vstack((smax, dat)), axis=0)
         kll.update(dat)
 
       # 0 should be near the median


### PR DESCRIPTION
Not specifying a numpy version should allow either to work.