### PR TITLE
Stop building wheels for EOLed 3.8, start on 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build-verbosity = 0  # options: 1, 2, or 3
-skip = ["cp36-*", "cp37-*", "pp*", "*-win32"]
+skip = ["cp36-*", "cp37-*", "cp38-*", "pp*", "*-win32"]
 
 [tool.cibuildwheel.windows]
 archs = ["auto64"]


### PR DESCRIPTION
Probably a bad branch name since the actual change is just stopping building 3.8.