### PR TITLE
Use system CMake when available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@
 [build-system]
 requires = ["wheel",
             "setuptools >= 30.3.0",
-            "cmake >= 3.16",
             "numpy",
             "nanobind >= 1.6"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Replace the unconditional build requirement of `cmake` with one that is added only if system CMake is not available, in order to facilitate building against system CMake when available.  This avoids unnecessary dependency on some systems, and improves portability when the particular target requires downstream patching of CMake.

While at it, also update the existing CMake check to use `shutil.which()` which is more efficient than spawning a subprocess, and update the error message to reference matching CMake version.